### PR TITLE
Fix laz-perf issue

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,18 @@ import dts from 'vite-plugin-dts';
 
 export default defineConfig({
   plugins: [
+    // Plugin to redirect @loaders.gl/las bundled laz-perf to browser version
+    // This avoids Node.js-specific require('fs') and require('path') calls
+    {
+      name: 'redirect-loaders-gl-laz-perf',
+      enforce: 'pre',
+      resolveId(id, importer) {
+        if (id.includes('laz-perf') && importer?.includes('@loaders.gl/las')) {
+          return resolve(__dirname, 'node_modules/laz-perf/lib/web/laz-perf.js');
+        }
+        return null;
+      },
+    },
     react(),
     dts({
       include: ['src'],
@@ -15,6 +27,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),
+      // Force laz-perf to use browser version (no fs/path requires)
+      'laz-perf': resolve(__dirname, 'node_modules/laz-perf/lib/web/index.js'),
     },
   },
   assetsInclude: ['**/*.wasm'],


### PR DESCRIPTION
Fix #41

 The require('fs') and require('path') calls were coming from two sources:
  1. The laz-perf package (used by copc)
  2. A bundled copy of laz-perf in @loaders.gl/las/dist/lib/libs/laz-perf.js

  While laz-perf provides both browser and Node.js builds, @loaders.gl/las bundles its own copy of the Node.js version.

  Fix Applied to vite.config.ts

  1. Added a Vite plugin that redirects @loaders.gl/las's bundled laz-perf imports to the browser version of the laz-perf package:

```javascript
  {
    name: 'redirect-loaders-gl-laz-perf',
    enforce: 'pre',
    resolveId(id, importer) {
      if (id.includes('laz-perf') && importer?.includes('@loaders.gl/las')) {
        return resolve(__dirname, 'node_modules/laz-perf/lib/web/laz-perf.js');
      }
      return null;
    },
  }
````

  2. Added a resolve alias for the laz-perf package to ensure all imports use the browser version.

  Results

  - Bundle size reduced from 1,313 KB to 769 KB (41% smaller)
  - No more require('fs') or require('path') calls in the distributed files