### PR TITLE
feat: Add GaussianSplatControl for 3D Gaussian splats visualization

### DIFF
--- a/examples/gaussian-splat/index.html
+++ b/examples/gaussian-splat/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gaussian Splat Example - maplibre-gl-lidar</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      #map {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/examples/gaussian-splat/main.ts
+++ b/examples/gaussian-splat/main.ts
@@ -1,0 +1,49 @@
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { GaussianSplatControl } from '../../src';
+
+const BASEMAP_STYLE = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+
+const map = new maplibregl.Map({
+  container: 'map',
+  style: BASEMAP_STYLE,
+  center: [0, 0],
+  zoom: 2,
+  pitch: 60,
+  maxPitch: 85,
+  antialias: true,
+});
+
+// Add navigation control
+map.addControl(new maplibregl.NavigationControl(), 'top-left');
+
+// Add Gaussian Splat control
+const splatControl = new GaussianSplatControl({
+  collapsed: false,
+  title: 'Gaussian Splats',
+  // Example splat URL - users can enter their own
+  defaultUrl: 'https://sparkjs.dev/assets/splats/butterfly.spz',
+});
+
+map.addControl(splatControl, 'top-right');
+
+// Listen for events
+splatControl.on('splatload', (event) => {
+  console.log('Splat loaded:', event.url, 'id:', event.splatId);
+});
+
+splatControl.on('splatremove', (event) => {
+  console.log('Splat removed:', event.splatId);
+});
+
+splatControl.on('error', (event) => {
+  console.error('Splat error:', event.error);
+});
+
+// Log when map is ready
+map.on('load', () => {
+  console.log('Map loaded. Enter a .splat, .ply, or .spz URL and click Load Splat.');
+  console.log('Example URLs:');
+  console.log('  - https://sparkjs.dev/assets/splats/butterfly.spz');
+  console.log('  - Your own Gaussian splat files');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,15 @@
         "@deck.gl/extensions": "^9.0.0",
         "@deck.gl/layers": "^9.0.0",
         "@deck.gl/mapbox": "^9.0.0",
+        "@dvt3d/maplibre-three-plugin": "^1.3.0",
         "@loaders.gl/core": "^4.3.4",
         "@loaders.gl/las": "^4.3.4",
+        "@sparkjsdev/spark": "^0.1.10",
         "@types/proj4": "^2.5.6",
         "copc": "^0.0.8",
         "maplibre-gl-layer-control": "^0.11.0",
-        "proj4": "^2.20.2"
+        "proj4": "^2.20.2",
+        "three": "^0.178.0"
       },
       "devDependencies": {
         "@rollup/plugin-replace": "^6.0.3",
@@ -27,6 +30,7 @@
         "@types/node": "^22.0.0",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
+        "@types/three": "^0.182.0",
         "@typescript-eslint/eslint-plugin": "^8.18.0",
         "@typescript-eslint/parser": "^8.18.0",
         "@vitejs/plugin-react": "^4.3.0",
@@ -581,6 +585,22 @@
         "@luma.gl/constants": "~9.2.6",
         "@luma.gl/core": "~9.2.6",
         "@math.gl/web-mercator": "^4.1.0"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@dvt3d/maplibre-three-plugin": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@dvt3d/maplibre-three-plugin/-/maplibre-three-plugin-1.3.0.tgz",
+      "integrity": "sha512-QOaaMMFpvuDxNoXAJUF/gMrsMXsvcGMurrEZwkg3E+jxee3HsvSPLSlKGJe2Y8jsftwKU9I56ZIUcPJ1poargg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": "^0.178.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2381,6 +2401,15 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/@sparkjsdev/spark": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@sparkjsdev/spark/-/spark-0.1.10.tgz",
+      "integrity": "sha512-CiijdZQuj7KPDUqIZPiEqyUkJCYo1JqR05vq/V+ElxMwqR7L70ZuZDyIKcasjZHSiPB8pGRMH8HZGqUKO9aRPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -2443,6 +2472,13 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
@@ -2583,6 +2619,13 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
@@ -2591,6 +2634,29 @@
       "dependencies": {
         "@types/geojson": "*"
       }
+    },
+    "node_modules/@types/three": {
+      "version": "0.182.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.182.0.tgz",
+      "integrity": "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.53.1",
@@ -3063,6 +3129,13 @@
       "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -4076,7 +4149,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -4870,6 +4942,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mgrs": {
       "version": "1.0.0",
@@ -5748,6 +5827,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/three": {
+      "version": "0.178.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
+      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -88,12 +88,15 @@
     "@deck.gl/extensions": "^9.0.0",
     "@deck.gl/layers": "^9.0.0",
     "@deck.gl/mapbox": "^9.0.0",
+    "@dvt3d/maplibre-three-plugin": "^1.3.0",
     "@loaders.gl/core": "^4.3.4",
     "@loaders.gl/las": "^4.3.4",
+    "@sparkjsdev/spark": "^0.1.10",
     "@types/proj4": "^2.5.6",
     "copc": "^0.0.8",
     "maplibre-gl-layer-control": "^0.11.0",
-    "proj4": "^2.20.2"
+    "proj4": "^2.20.2",
+    "three": "^0.178.0"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^6.0.3",
@@ -102,6 +105,7 @@
     "@types/node": "^22.0.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
+    "@types/three": "^0.182.0",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
     "@vitejs/plugin-react": "^4.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import './lib/styles/lidar-control.css';
 
 // Main entry point - Core exports
 export { LidarControl } from './lib/core/LidarControl';
+export { GaussianSplatControl } from './lib/core/GaussianSplatControl';
 export { DeckOverlay } from './lib/core/DeckOverlay';
 export { ViewportManager } from './lib/core/ViewportManager';
 export { PointCloudLoader } from './lib/loaders/PointCloudLoader';
@@ -22,6 +23,14 @@ export { ElevationProfileChart } from './lib/gui/ElevationProfileChart';
 
 // Layer control adapter
 export { LidarLayerAdapter } from './lib/adapters';
+
+// Gaussian splat types
+export type {
+  GaussianSplatControlOptions,
+  GaussianSplatControlState,
+  GaussianSplatEvent,
+  GaussianSplatEventHandler,
+} from './lib/core/GaussianSplatControl';
 
 // Type exports
 export type {

--- a/src/lib/core/GaussianSplatControl.ts
+++ b/src/lib/core/GaussianSplatControl.ts
@@ -1,0 +1,708 @@
+import type { IControl, Map as MapLibreMap, ControlPosition } from 'maplibre-gl';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - THREE types
+import * as THREE from 'three';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - MTP types
+import * as MTP from '@dvt3d/maplibre-three-plugin';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - Spark types
+import { SplatMesh } from '@sparkjsdev/spark';
+
+/**
+ * Options for configuring the GaussianSplatControl.
+ */
+export interface GaussianSplatControlOptions {
+  /** Position on the map. Default: 'top-right'. */
+  position?: ControlPosition;
+  /** Custom CSS class name. */
+  className?: string;
+  /** Whether the control starts collapsed. Default: true. */
+  collapsed?: boolean;
+  /** Title for the control panel. Default: 'Gaussian Splats'. */
+  title?: string;
+  /** Panel width in pixels. Default: 320. */
+  panelWidth?: number;
+  /** Default URL to load. */
+  defaultUrl?: string;
+  /** Auto-load the default URL when control is added. Default: false. */
+  loadDefaultUrl?: boolean;
+  /** Default opacity (0-1). Default: 1. */
+  defaultOpacity?: number;
+  /** Default rotation in degrees [x, y, z]. Default: [0, 0, 0]. */
+  defaultRotation?: [number, number, number];
+  /** Default scale. Default: 1. */
+  defaultScale?: number;
+}
+
+/**
+ * Internal state of the GaussianSplatControl.
+ */
+export interface GaussianSplatControlState {
+  collapsed: boolean;
+  url: string;
+  loading: boolean;
+  error: string | null;
+  status: string | null;
+  hasLayer: boolean;
+  layerCount: number;
+  opacity: number;
+  rotation: [number, number, number];
+  scale: number;
+  longitude: number;
+  latitude: number;
+  altitude: number;
+}
+
+/**
+ * Event types for the GaussianSplatControl.
+ */
+export type GaussianSplatEvent =
+  | 'expand'
+  | 'collapse'
+  | 'show'
+  | 'hide'
+  | 'splatload'
+  | 'splatremove'
+  | 'error';
+
+/**
+ * Event handler function type.
+ */
+export type GaussianSplatEventHandler = (event: {
+  type: GaussianSplatEvent;
+  state: GaussianSplatControlState;
+  url?: string;
+  error?: string;
+  splatId?: string;
+}) => void;
+
+/**
+ * Internal splat layer info.
+ */
+interface SplatLayerInfo {
+  id: string;
+  url: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mesh: any; // SplatMesh
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rtcGroup: any; // MTP.RTCGroup
+  longitude: number;
+  latitude: number;
+  altitude: number;
+}
+
+/**
+ * Default options for the GaussianSplatControl.
+ */
+const DEFAULT_OPTIONS: Required<GaussianSplatControlOptions> = {
+  position: 'top-right',
+  className: '',
+  collapsed: true,
+  title: 'Gaussian Splats',
+  panelWidth: 320,
+  defaultUrl: '',
+  loadDefaultUrl: false,
+  defaultOpacity: 1,
+  defaultRotation: [0, 0, 0],
+  defaultScale: 1,
+};
+
+/**
+ * Splat icon SVG for the control button.
+ */
+const SPLAT_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="3"/>
+  <circle cx="12" cy="12" r="7" stroke-dasharray="4 2"/>
+  <circle cx="12" cy="12" r="10" stroke-dasharray="2 3"/>
+</svg>`;
+
+/**
+ * A control for loading and displaying Gaussian Splat 3D scenes on a MapLibre map.
+ * 
+ * Supports .splat, .ply, .spz, .ksplat, and .sog file formats.
+ * Uses THREE.js via maplibre-three-plugin for rendering.
+ *
+ * @example
+ * ```typescript
+ * const splatControl = new GaussianSplatControl({
+ *   defaultUrl: 'https://example.com/scene.splat',
+ *   loadDefaultUrl: true,
+ * });
+ * map.addControl(splatControl, 'top-right');
+ * ```
+ */
+export class GaussianSplatControl implements IControl {
+  private _map?: MapLibreMap;
+  private _container?: HTMLElement;
+  // @ts-expect-error - Used for future panel reference
+  private _panel?: HTMLElement;
+  private _options: Required<GaussianSplatControlOptions>;
+  private _state: GaussianSplatControlState;
+  private _eventHandlers: Map<GaussianSplatEvent, Set<GaussianSplatEventHandler>> = new Map();
+  
+  // THREE.js / MapLibre bridge
+  private _mapScene?: MTP.MapScene;
+  private _splatLayers: Map<string, SplatLayerInfo> = new Map();
+  private _layerCounter = 0;
+
+  constructor(options?: GaussianSplatControlOptions) {
+    this._options = { ...DEFAULT_OPTIONS, ...options };
+    this._state = {
+      collapsed: this._options.collapsed,
+      url: this._options.defaultUrl,
+      loading: false,
+      error: null,
+      status: null,
+      hasLayer: false,
+      layerCount: 0,
+      opacity: this._options.defaultOpacity,
+      rotation: this._options.defaultRotation,
+      scale: this._options.defaultScale,
+      longitude: 0,
+      latitude: 0,
+      altitude: 0,
+    };
+  }
+
+  onAdd(map: MapLibreMap): HTMLElement {
+    this._map = map;
+    this._container = this._createContainer();
+    this._render();
+
+    // Initialize THREE.js scene
+    this._initMapScene();
+
+    // Auto-load default URL if specified
+    if (this._options.loadDefaultUrl && this._options.defaultUrl) {
+      map.once('idle', () => {
+        this.loadSplat(this._options.defaultUrl);
+      });
+    }
+
+    return this._container;
+  }
+
+  onRemove(): void {
+    this._removeAllSplats();
+    
+    this._mapScene = undefined;
+    this._map = undefined;
+    this._container?.parentNode?.removeChild(this._container);
+    this._container = undefined;
+    this._panel = undefined;
+  }
+
+  getDefaultPosition(): ControlPosition {
+    return this._options.position;
+  }
+
+  /**
+   * Expand the control panel.
+   */
+  expand(): void {
+    if (this._state.collapsed) {
+      this._state.collapsed = false;
+      this._render();
+      this._emit('expand', {});
+    }
+  }
+
+  /**
+   * Collapse the control panel.
+   */
+  collapse(): void {
+    if (!this._state.collapsed) {
+      this._state.collapsed = true;
+      this._render();
+      this._emit('collapse', {});
+    }
+  }
+
+  /**
+   * Toggle the control panel.
+   */
+  toggle(): void {
+    if (this._state.collapsed) this.expand();
+    else this.collapse();
+  }
+
+  /**
+   * Get the current state.
+   */
+  getState(): GaussianSplatControlState {
+    return { ...this._state };
+  }
+
+  /**
+   * Add an event listener.
+   */
+  on(event: GaussianSplatEvent, handler: GaussianSplatEventHandler): void {
+    if (!this._eventHandlers.has(event)) {
+      this._eventHandlers.set(event, new Set());
+    }
+    this._eventHandlers.get(event)!.add(handler);
+  }
+
+  /**
+   * Remove an event listener.
+   */
+  off(event: GaussianSplatEvent, handler: GaussianSplatEventHandler): void {
+    this._eventHandlers.get(event)?.delete(handler);
+  }
+
+  /**
+   * Load a Gaussian splat from a URL.
+   */
+  async loadSplat(url: string, options?: {
+    longitude?: number;
+    latitude?: number;
+    altitude?: number;
+    rotation?: [number, number, number];
+    scale?: number;
+  }): Promise<string> {
+    if (!this._map || !this._mapScene) {
+      throw new Error('Map not initialized');
+    }
+
+    const lng = options?.longitude ?? (this._state.longitude || this._map.getCenter().lng);
+    const lat = options?.latitude ?? (this._state.latitude || this._map.getCenter().lat);
+    const alt = options?.altitude ?? (this._state.altitude || 0);
+    const rotation = options?.rotation ?? this._state.rotation;
+    const scale = options?.scale ?? this._state.scale;
+
+    this._state.url = url;
+    this._state.loading = true;
+    this._state.error = null;
+    this._state.status = 'Loading splat...';
+    this._state.longitude = lng;
+    this._state.latitude = lat;
+    this._state.altitude = alt;
+    this._render();
+
+    try {
+      // Create RTC group for georeferenced positioning
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rtcGroup = (MTP.Creator as any).createMercatorRTCGroup(
+        [lng, lat, alt],
+        [
+          THREE.MathUtils.degToRad(rotation[0] - 90), // Adjust for splat orientation
+          THREE.MathUtils.degToRad(rotation[1] + 90),
+          THREE.MathUtils.degToRad(rotation[2]),
+        ],
+        scale
+      );
+
+      // Create and load the splat mesh
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const splatMesh = new (SplatMesh as any)({ url });
+      
+      // Wait for the mesh to load
+      await new Promise<void>((resolve, reject) => {
+        const checkLoaded = () => {
+          // SplatMesh loads asynchronously - check if ready
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          if ((splatMesh as any).geometry && (splatMesh as any).geometry.attributes?.position) {
+            resolve();
+          } else {
+            setTimeout(checkLoaded, 100);
+          }
+        };
+        checkLoaded();
+        // Timeout after 60 seconds
+        setTimeout(() => reject(new Error('Splat loading timeout')), 60000);
+      });
+
+      // Apply scale
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (splatMesh as any).scale?.setScalar(scale);
+
+      // Add to RTC group and scene
+      rtcGroup.add(splatMesh);
+      this._mapScene.addObject(rtcGroup);
+
+      // Store layer info
+      const layerId = `splat-${this._layerCounter++}`;
+      this._splatLayers.set(layerId, {
+        id: layerId,
+        url,
+        mesh: splatMesh,
+        rtcGroup,
+        longitude: lng,
+        latitude: lat,
+        altitude: alt,
+      });
+
+      // Fly to location
+      this._map.flyTo({
+        center: [lng, lat],
+        zoom: 18,
+        pitch: 60,
+        duration: 1500,
+      });
+
+      this._state.hasLayer = true;
+      this._state.layerCount = this._splatLayers.size;
+      this._state.loading = false;
+      this._state.status = `Loaded: ${this._getFilename(url)}`;
+      this._render();
+      this._emit('splatload', { url, splatId: layerId });
+
+      return layerId;
+    } catch (err) {
+      this._state.loading = false;
+      this._state.error = `Failed to load: ${err instanceof Error ? err.message : String(err)}`;
+      this._render();
+      this._emit('error', { error: this._state.error });
+      throw err;
+    }
+  }
+
+  /**
+   * Remove a splat layer by ID.
+   */
+  removeSplat(layerId: string): void {
+    const layer = this._splatLayers.get(layerId);
+    if (!layer || !this._mapScene) return;
+
+    this._mapScene.removeObject(layer.rtcGroup);
+    this._splatLayers.delete(layerId);
+
+    this._state.hasLayer = this._splatLayers.size > 0;
+    this._state.layerCount = this._splatLayers.size;
+    this._state.status = null;
+    this._render();
+    this._emit('splatremove', { splatId: layerId });
+  }
+
+  /**
+   * Remove all splat layers.
+   */
+  private _removeAllSplats(): void {
+    for (const [layerId] of this._splatLayers) {
+      this.removeSplat(layerId);
+    }
+  }
+
+  private _emit(
+    event: GaussianSplatEvent,
+    extra?: { url?: string; error?: string; splatId?: string }
+  ): void {
+    const handlers = this._eventHandlers.get(event);
+    if (!handlers) return;
+    const payload = { type: event, state: this._state, ...extra };
+    for (const handler of handlers) {
+      handler(payload);
+    }
+  }
+
+  private _initMapScene(): void {
+    if (!this._map) return;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mapScene = new (MTP.MapScene as any)(this._map as any);
+    this._mapScene = mapScene;
+    mapScene.addLight(new THREE.AmbientLight(0xffffff, 1));
+    mapScene.addLight(new THREE.DirectionalLight(0xffffff, 0.5));
+
+    // Trigger repaint on post-render
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mapScene.on('postRender', () => {
+      this._map?.triggerRepaint();
+    });
+  }
+
+  private _createContainer(): HTMLElement {
+    const container = document.createElement('div');
+    container.className = `maplibregl-ctrl maplibre-gl-gaussian-splat ${this._options.className || ''}`;
+    container.style.background = 'rgba(255, 255, 255, 0.95)';
+    container.style.borderRadius = '4px';
+    return container;
+  }
+
+  private _render(): void {
+    if (!this._container) return;
+    this._container.innerHTML = '';
+
+    if (this._state.collapsed) {
+      this._renderCollapsed();
+    } else {
+      this._renderExpanded();
+    }
+  }
+
+  private _renderCollapsed(): void {
+    if (!this._container) return;
+
+    const button = document.createElement('button');
+    button.className = `maplibre-gl-gaussian-splat-button${this._state.hasLayer ? ' active' : ''}`;
+    button.innerHTML = SPLAT_ICON;
+    button.title = this._options.title;
+    button.style.cssText = `
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 29px;
+      height: 29px;
+      padding: 0;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      color: ${this._state.hasLayer ? '#0078d7' : '#333'};
+    `;
+    button.addEventListener('click', () => this.expand());
+
+    this._container.appendChild(button);
+  }
+
+  private _renderExpanded(): void {
+    if (!this._container) return;
+
+    const panel = document.createElement('div');
+    panel.className = 'maplibre-gl-gaussian-splat-panel';
+    panel.style.cssText = `
+      padding: 12px;
+      width: ${this._options.panelWidth}px;
+      font-size: 13px;
+      color: #333;
+    `;
+
+    // Header
+    const header = document.createElement('div');
+    header.style.cssText = `
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 12px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid #e0e0e0;
+    `;
+
+    const title = document.createElement('span');
+    title.textContent = this._options.title;
+    title.style.cssText = 'font-weight: 600; font-size: 14px;';
+    header.appendChild(title);
+
+    const closeBtn = document.createElement('button');
+    closeBtn.innerHTML = '×';
+    closeBtn.style.cssText = `
+      background: transparent;
+      border: none;
+      font-size: 20px;
+      color: #666;
+      cursor: pointer;
+      padding: 0 4px;
+      line-height: 1;
+    `;
+    closeBtn.addEventListener('click', () => this.collapse());
+    header.appendChild(closeBtn);
+
+    panel.appendChild(header);
+
+    // URL input
+    const urlGroup = this._createFormGroup('Splat URL (.splat, .ply, .spz)');
+    const urlInput = document.createElement('input');
+    urlInput.type = 'text';
+    urlInput.placeholder = 'https://example.com/scene.splat';
+    urlInput.value = this._state.url;
+    urlInput.style.cssText = `
+      width: 100%;
+      padding: 8px 10px;
+      font-size: 12px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      box-sizing: border-box;
+    `;
+    urlInput.addEventListener('input', () => {
+      this._state.url = urlInput.value;
+    });
+    urlGroup.appendChild(urlInput);
+    panel.appendChild(urlGroup);
+
+    // Location inputs
+    const locGroup = this._createFormGroup('Location (Longitude, Latitude, Altitude)');
+    const locRow = document.createElement('div');
+    locRow.style.cssText = 'display: flex; gap: 8px;';
+
+    const lngInput = this._createNumberInput('Lng', this._state.longitude, (v) => { this._state.longitude = v; });
+    const latInput = this._createNumberInput('Lat', this._state.latitude, (v) => { this._state.latitude = v; });
+    const altInput = this._createNumberInput('Alt', this._state.altitude, (v) => { this._state.altitude = v; });
+
+    locRow.appendChild(lngInput);
+    locRow.appendChild(latInput);
+    locRow.appendChild(altInput);
+    locGroup.appendChild(locRow);
+    panel.appendChild(locGroup);
+
+    // Scale input
+    const scaleGroup = this._createFormGroup('Scale');
+    const scaleInput = document.createElement('input');
+    scaleInput.type = 'number';
+    scaleInput.step = '0.1';
+    scaleInput.value = String(this._state.scale);
+    scaleInput.style.cssText = `
+      width: 100%;
+      padding: 8px 10px;
+      font-size: 12px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      box-sizing: border-box;
+    `;
+    scaleInput.addEventListener('input', () => {
+      this._state.scale = Number(scaleInput.value) || 1;
+    });
+    scaleGroup.appendChild(scaleInput);
+    panel.appendChild(scaleGroup);
+
+    // Load button
+    const loadBtn = document.createElement('button');
+    loadBtn.textContent = 'Load Splat';
+    loadBtn.disabled = this._state.loading || !this._state.url;
+    loadBtn.style.cssText = `
+      width: 100%;
+      padding: 10px 16px;
+      font-size: 12px;
+      font-weight: 500;
+      border: none;
+      border-radius: 4px;
+      background: #0078d7;
+      color: white;
+      cursor: pointer;
+      margin-top: 12px;
+      opacity: ${this._state.loading || !this._state.url ? '0.5' : '1'};
+    `;
+    loadBtn.addEventListener('click', () => {
+      if (this._state.url) {
+        this.loadSplat(this._state.url);
+      }
+    });
+    panel.appendChild(loadBtn);
+
+    // Status/error
+    if (this._state.loading) {
+      panel.appendChild(this._createStatus('Loading...', 'info'));
+    } else if (this._state.error) {
+      panel.appendChild(this._createStatus(this._state.error, 'error'));
+    } else if (this._state.status) {
+      panel.appendChild(this._createStatus(this._state.status, 'success'));
+    }
+
+    // Layer list
+    if (this._splatLayers.size > 0) {
+      const listDiv = document.createElement('div');
+      listDiv.style.cssText = `
+        margin-top: 16px;
+        border-top: 1px solid #e0e0e0;
+        padding-top: 12px;
+      `;
+
+      const listHeader = document.createElement('div');
+      listHeader.textContent = `Layers (${this._splatLayers.size})`;
+      listHeader.style.cssText = 'font-size: 12px; font-weight: 500; color: #555; margin-bottom: 8px;';
+      listDiv.appendChild(listHeader);
+
+      for (const [layerId, layer] of this._splatLayers) {
+        const item = document.createElement('div');
+        item.style.cssText = `
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding: 6px 8px;
+          background: #f8f8f8;
+          border-radius: 4px;
+          margin-bottom: 4px;
+          font-size: 11px;
+        `;
+
+        const label = document.createElement('span');
+        label.textContent = this._getFilename(layer.url);
+        label.style.cssText = 'flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;';
+        item.appendChild(label);
+
+        const removeBtn = document.createElement('button');
+        removeBtn.innerHTML = '×';
+        removeBtn.title = 'Remove';
+        removeBtn.style.cssText = `
+          border: none;
+          background: transparent;
+          cursor: pointer;
+          color: #999;
+          font-size: 14px;
+          padding: 0 4px;
+        `;
+        removeBtn.addEventListener('click', () => {
+          this.removeSplat(layerId);
+        });
+        item.appendChild(removeBtn);
+
+        listDiv.appendChild(item);
+      }
+
+      panel.appendChild(listDiv);
+    }
+
+    this._container.appendChild(panel);
+    this._panel = panel;
+  }
+
+  private _createFormGroup(label: string): HTMLElement {
+    const group = document.createElement('div');
+    group.style.marginBottom = '12px';
+
+    const labelEl = document.createElement('label');
+    labelEl.textContent = label;
+    labelEl.style.cssText = 'display: block; font-size: 12px; font-weight: 500; color: #555; margin-bottom: 4px;';
+    group.appendChild(labelEl);
+
+    return group;
+  }
+
+  private _createNumberInput(placeholder: string, value: number, onChange: (v: number) => void): HTMLElement {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = 'any';
+    input.placeholder = placeholder;
+    input.value = String(value);
+    input.style.cssText = `
+      flex: 1;
+      padding: 6px 8px;
+      font-size: 11px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      box-sizing: border-box;
+      min-width: 0;
+    `;
+    input.addEventListener('input', () => {
+      onChange(Number(input.value) || 0);
+    });
+    return input;
+  }
+
+  private _createStatus(message: string, type: 'info' | 'error' | 'success'): HTMLElement {
+    const status = document.createElement('div');
+    const colors = {
+      info: { bg: '#e3f2fd', color: '#1565c0' },
+      error: { bg: '#ffebee', color: '#c62828' },
+      success: { bg: '#e8f5e9', color: '#2e7d32' },
+    };
+    status.textContent = message;
+    status.style.cssText = `
+      margin-top: 12px;
+      padding: 8px 10px;
+      font-size: 11px;
+      border-radius: 4px;
+      background: ${colors[type].bg};
+      color: ${colors[type].color};
+    `;
+    return status;
+  }
+
+  private _getFilename(url: string): string {
+    try {
+      const path = new URL(url).pathname;
+      return path.split('/').pop() || url;
+    } catch {
+      return url.split('/').pop() || url;
+    }
+  }
+}

--- a/src/lib/core/GaussianSplatControl.ts
+++ b/src/lib/core/GaussianSplatControl.ts
@@ -119,7 +119,7 @@ const SPLAT_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="1
 
 /**
  * A control for loading and displaying Gaussian Splat 3D scenes on a MapLibre map.
- * 
+ *
  * Supports .splat, .ply, .spz, .ksplat, and .sog file formats.
  * Uses THREE.js via maplibre-three-plugin for rendering.
  *
@@ -140,7 +140,7 @@ export class GaussianSplatControl implements IControl {
   private _options: Required<GaussianSplatControlOptions>;
   private _state: GaussianSplatControlState;
   private _eventHandlers: Map<GaussianSplatEvent, Set<GaussianSplatEventHandler>> = new Map();
-  
+
   // THREE.js / MapLibre bridge
   private _mapScene?: MTP.MapScene;
   private _splatLayers: Map<string, SplatLayerInfo> = new Map();
@@ -185,7 +185,7 @@ export class GaussianSplatControl implements IControl {
 
   onRemove(): void {
     this._removeAllSplats();
-    
+
     this._mapScene = undefined;
     this._map = undefined;
     this._container?.parentNode?.removeChild(this._container);
@@ -296,7 +296,7 @@ export class GaussianSplatControl implements IControl {
       // Create and load the splat mesh
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const splatMesh = new (SplatMesh as any)({ url });
-      
+
       // Wait for the mesh to load
       await new Promise<void>((resolve, reject) => {
         const checkLoaded = () => {


### PR DESCRIPTION
## Summary

Adds support for visualizing 3D Gaussian Splats on MapLibre maps, addressing issue #37.

## Implementation

Uses a combination of:
- **[@dvt3d/maplibre-three-plugin](https://github.com/dvt3d/maplibre-three-plugin)** - Bridges MapLibre GL JS with Three.js
- **[@sparkjsdev/spark](https://github.com/sparkjsdev/spark)** - Advanced 3D Gaussian Splatting renderer for Three.js

## Features

- `GaussianSplatControl` component with GUI for loading splats
- Supports multiple file formats: `.splat`, `.ply`, `.spz`, `.ksplat`, `.sog`
- Configurable georeferenced positioning:
  - Longitude, Latitude, Altitude
  - Rotation (X, Y, Z)
  - Scale
- Auto fly-to when loading splats
- Layer management (add/remove multiple splats)
- Event system for load, remove, and error events

## Usage

```typescript
import { GaussianSplatControl } from 'maplibre-gl-lidar';

const splatControl = new GaussianSplatControl({
  collapsed: false,
  defaultUrl: 'https://example.com/scene.splat',
  loadDefaultUrl: true,
});
map.addControl(splatControl, 'top-right');

// Events
splatControl.on('splatload', (event) => {
  console.log('Splat loaded:', event.url);
});
```

## Example

Added example at `examples/gaussian-splat/`

## Dependencies Added

- `@dvt3d/maplibre-three-plugin`
- `@sparkjsdev/spark`
- `three` (peer dependency)

## References

- https://github.com/bertt/qgis_gaussiansplats_plugin
- https://github.com/sparkjsdev/spark
- https://github.com/dvt3d/maplibre-three-plugin

Closes #37