### PR TITLE
Rename panelMaxHeight to maxHeight

### DIFF
--- a/examples/basic/main.ts
+++ b/examples/basic/main.ts
@@ -75,7 +75,7 @@ map.on('load', () => {
     },
     // copcLoadingMode: 'dynamic',  // Auto-detected for COPC URLs, use 'full' to force download
     // streamingPointBudget: 5_000_000  // Max points in memory for streaming mode
-    // panelMaxHeight: 600,
+    // maxHeight: 500,
   });
 
   // Create layer adapter for the layer control

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-lidar",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A MapLibre GL JS plugin for visualizing LiDAR point clouds using deck.gl",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/lib/core/LidarControl.ts
+++ b/src/lib/core/LidarControl.ts
@@ -38,7 +38,7 @@ const DEFAULT_OPTIONS: Required<Omit<LidarControlOptions, 'pickInfoFields' | 'co
   position: 'top-right',
   title: 'LiDAR Viewer',
   panelWidth: 365,
-  panelMaxHeight: 600,
+  maxHeight: 500,
   className: '',
   pointSize: 2,
   opacity: 1.0,
@@ -139,7 +139,7 @@ export class LidarControl implements IControl {
     this._state = {
       collapsed: this._options.collapsed,
       panelWidth: this._options.panelWidth,
-      panelMaxHeight: this._options.panelMaxHeight,
+      maxHeight: this._options.maxHeight,
       pointClouds: [],
       activePointCloudId: null,
       pointSize: this._options.pointSize,

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -118,7 +118,7 @@ export interface LidarControlOptions {
    * When content exceeds this height, a vertical scrollbar appears.
    * @default 500
    */
-  panelMaxHeight?: number;
+  maxHeight?: number;
 
   /**
    * Custom CSS class name for the control container
@@ -264,7 +264,7 @@ export interface LidarControlOptions {
 export interface LidarState {
   collapsed: boolean;
   panelWidth: number;
-  panelMaxHeight: number;
+  maxHeight: number;
   pointClouds: PointCloudInfo[];
   activePointCloudId: string | null;
   pointSize: number;

--- a/src/lib/gui/PanelBuilder.ts
+++ b/src/lib/gui/PanelBuilder.ts
@@ -84,8 +84,8 @@ export class PanelBuilder {
     const content = document.createElement('div');
     content.className = 'lidar-control-content';
     // Apply max height from state
-    if (this._state.panelMaxHeight) {
-      content.style.maxHeight = `${this._state.panelMaxHeight}px`;
+    if (this._state.maxHeight) {
+      content.style.maxHeight = `${this._state.maxHeight}px`;
     }
     this._contentElement = content;
 
@@ -122,8 +122,8 @@ export class PanelBuilder {
     this._state = state;
 
     // Update max height if changed
-    if (this._contentElement && state.panelMaxHeight) {
-      this._contentElement.style.maxHeight = `${state.panelMaxHeight}px`;
+    if (this._contentElement && state.maxHeight) {
+      this._contentElement.style.maxHeight = `${state.maxHeight}px`;
     }
 
     // Update loading state

--- a/src/lib/hooks/useLidarState.ts
+++ b/src/lib/hooks/useLidarState.ts
@@ -7,7 +7,7 @@ import type { LidarState, ColorScheme } from '../core/types';
 const DEFAULT_STATE: LidarState = {
   collapsed: true,
   panelWidth: 365,
-  panelMaxHeight: 600,
+  maxHeight: 500,
   pointClouds: [],
   activePointCloudId: null,
   pointSize: 2,

--- a/src/lib/styles/lidar-control.css
+++ b/src/lib/styles/lidar-control.css
@@ -55,7 +55,6 @@
   border-radius: 4px;
   box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
   width: 380px;
-  max-height: 80vh;
   overflow-y: auto;
   overflow-x: hidden;
   z-index: 1000;


### PR DESCRIPTION
## Summary
- Rename `panelMaxHeight` → `maxHeight` in `LidarControlOptions` and `LidarState` for consistency with other maplibre-gl plugins
- Change default from 600 to 500 to match convention across controls
- Remove hardcoded `max-height: 80vh` from CSS (JS inline styles handle it)
- Update PanelBuilder, React hook defaults, and example

## Test plan
- [x] `npm run build` passes
- [ ] Panel respects `maxHeight` option when set
- [ ] Vertical scrollbar appears when content exceeds maxHeight