### PR TITLE
Add getPanelElement() for ControlGrid integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-lidar",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-lidar",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@deck.gl/core": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-lidar",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A MapLibre GL JS plugin for visualizing LiDAR point clouds using deck.gl",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/lib/core/LidarControl.ts
+++ b/src/lib/core/LidarControl.ts
@@ -2695,4 +2695,8 @@ export class LidarControl implements IControl {
     }
     return this._crossSectionPanel;
   }
+
+  getPanelElement(): HTMLElement | null {
+    return this._panel ?? null;
+  }
 }


### PR DESCRIPTION
## Summary
- Add `getPanelElement()` method that exposes the panel element
- Enables ControlGrid to relocate the panel from `map.getContainer()` into its floating panel, preventing overlay issues

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all 21 tests pass
- [ ] Manual: expand control inside ControlGrid — panel appears below grid, not overlaid