### PR TITLE
ci: switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,12 +7,18 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -24,6 +30,4 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm


### PR DESCRIPTION
## Summary
- The classic NPM_TOKEN path is now returning 404 from `PUT https://registry.npmjs.org/maplibre-gl-lidar`, which is npm's standard "auth failed" response. This blocked the 0.12.0 release.
- The package already has a Trusted Publisher configured on npmjs.com pointing at this repo and `publish.yml`, so switch the workflow to OIDC: grant `id-token: write`, drop `NODE_AUTH_TOKEN`, upgrade npm to a version that supports trusted publishing, and publish with `--provenance --access public` to attach build provenance.

## Test plan
- [ ] After merge, retry the failed release (or cut a fresh patch release) and confirm `npm publish` succeeds without `NPM_TOKEN`.
- [ ] Verify the published version shows a provenance badge on npmjs.com.
- [ ] Once confirmed working, the `NPM_TOKEN` repo secret can be deleted.