### PR TITLE
ci: run npm publish via npx for OIDC-capable npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,6 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: npm ci
 
@@ -30,4 +27,4 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npx -y npm@latest publish --provenance --access public


### PR DESCRIPTION
## Summary
- The previous workflow's `npm install -g npm@latest` step fails on the runner with `Cannot find module 'promise-retry'` (a known regression in the bundled npm 10's installer), so publish never ran.
- Replace the global upgrade with `npx -y npm@latest publish --provenance --access public`. This pulls a fresh npm 11+ into a temp install for just the publish command, supports Trusted Publishing OIDC, and leaves the runner's global npm untouched.

## Test plan
- [ ] Re-run the failed release workflow (or cut a fresh patch tag) and confirm `npm publish` succeeds via OIDC, with no `NPM_TOKEN`.
- [ ] Verify provenance shows up on the npm package page.