### PR TITLE
feat: add shareable URL for LiDAR state

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ const showOnlyBuildings = () => {
 </template>
 ```
 
-Available methods: `loadPointCloud`, `unloadPointCloud`, `flyToPointCloud`, `setPointSize`, `setColorScheme`, `setOpacity`, `setPickable`, `setUsePercentile`, `setElevationRange`, `clearElevationRange`, `setZOffset`, `setZOffsetEnabled`, `toggle`, `expand`, `collapse`, `getState`, `getPointClouds`, `stopStreaming`, `isStreaming`.
+Available methods: `loadPointCloud`, `unloadPointCloud`, `flyToPointCloud`, `setPointSize`, `setColorScheme`, `setOpacity`, `setPickable`, `setUsePercentile`, `setElevationRange`, `clearElevationRange`, `setZOffset`, `setZOffsetEnabled`, `getShareUrl`, `restoreFromUrl`, `toggle`, `expand`, `collapse`, `getState`, `getPointClouds`, `stopStreaming`, `isStreaming`.
 
 **Vue examples:** [EPT Streaming](https://mapcn-vue.geoql.in/examples/lidar-ept) · [Classification Filter](https://mapcn-vue.geoql.in/examples/lidar-classification)
 **Full docs:** [@geoql/v-maplibre LidarControl](https://v-maplibre.geoql.in/controls/lidar)
@@ -268,6 +268,8 @@ interface LidarControlOptions {
 
   // Behavior
   autoZoom?: boolean; // Auto zoom to data after loading (default: true)
+  shareUrl?: boolean; // Show Share URL button in the panel (default: true)
+  restoreFromUrl?: boolean; // Restore from Share URL query params on add (default: true)
 
   // COPC Streaming (dynamic loading)
   copcLoadingMode?: "full" | "dynamic"; // Loading mode for COPC files (default: 'dynamic')
@@ -287,6 +289,8 @@ stopStreaming(): void  // Stop dynamic loading and clean up
 unloadPointCloud(id?: string): void
 getPointClouds(): PointCloudInfo[]
 flyToPointCloud(id?: string): void
+getShareUrl(): string
+restoreFromUrl(url?: string): Promise<PointCloudInfo[]>
 
 // Styling
 setPointSize(size: number): void
@@ -327,6 +331,8 @@ off(event: LidarControlEvent, handler: LidarControlEventHandler): void
 getState(): LidarState
 getMap(): MapLibreMap | undefined
 ```
+
+Share URLs use readable query parameters such as `url`, `lon`, `lat`, `zoom`, `pitch`, `bearing`, `color`, `cmap`, `size`, `opacity`, and `zoff`.
 
 #### Events
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,4 +89,18 @@ export {
   formatNumber,
   formatBytes,
   getFilename,
+  LIDAR_SHARE_PARAM,
+  LIDAR_SHARE_VERSION,
+  createLidarSharePayload,
+  encodeLidarSharePayload,
+  decodeLidarSharePayload,
+  createLidarShareUrl,
+  parseLidarSharePayloadFromUrl,
+  hasLidarShareParams,
+} from './lib/utils';
+
+export type {
+  LidarShareMapState,
+  LidarShareVisualization,
+  LidarSharePayload,
 } from './lib/utils';

--- a/src/lib/core/LidarControl.ts
+++ b/src/lib/core/LidarControl.ts
@@ -28,6 +28,11 @@ import { CrossSectionPanel } from '../gui/CrossSectionPanel';
 import { CrossSectionTool } from '../tools/CrossSectionTool';
 import { ElevationProfileExtractor } from '../tools/ElevationProfileExtractor';
 import { generateId, getFilename, computePercentileBounds } from '../utils/helpers';
+import {
+  createLidarSharePayload,
+  createLidarShareUrl,
+  parseLidarSharePayloadFromUrl,
+} from '../utils/share-url';
 import { getAvailableClassifications } from '../colorizers/ColorScheme';
 
 /**
@@ -61,6 +66,8 @@ const DEFAULT_OPTIONS: Required<Omit<LidarControlOptions, 'pickInfoFields' | 'co
   streamingViewportDebounceMs: 150,
   terrainEnabled: false,
   terrainExaggeration: 1.0,
+  shareUrl: true,
+  restoreFromUrl: true,
 };
 
 /**
@@ -223,6 +230,12 @@ export class LidarControl implements IControl {
       this.setTerrain(true);
     }
 
+    if (this._options.restoreFromUrl) {
+      this.restoreFromUrl().catch((err) => {
+        console.warn('Failed to restore LiDAR state from URL:', err);
+      });
+    }
+
     return this._container;
   }
 
@@ -282,6 +295,93 @@ export class LidarControl implements IControl {
   }
 
   /**
+   * Creates a shareable URL that restores URL-loaded point clouds, map camera, and visualization state.
+   *
+   * @returns Shareable URL
+   */
+  getShareUrl(): string {
+    const currentUrl =
+      typeof window !== 'undefined' ? window.location.href : 'http://localhost/';
+    const payload = createLidarSharePayload(
+      this._state,
+      this._getShareMapState(),
+      currentUrl
+    );
+
+    return createLidarShareUrl(currentUrl, payload);
+  }
+
+  /**
+   * Restores point clouds, map camera, and visualization state from a share URL.
+   *
+   * @param url - URL to restore from. Defaults to the current browser URL.
+   * @returns Loaded point cloud info objects
+   */
+  async restoreFromUrl(url?: string): Promise<PointCloudInfo[]> {
+    const restoreUrl =
+      url ?? (typeof window !== 'undefined' ? window.location.href : undefined);
+    if (!restoreUrl) return [];
+
+    const payload = parseLidarSharePayloadFromUrl(restoreUrl);
+    if (!payload) return [];
+
+    const visualization = payload.visualization;
+    this.setPointSize(visualization.pointSize);
+    this.setOpacity(visualization.opacity);
+    this.setColorScheme(visualization.colorScheme);
+    this.setColormap(visualization.colormap);
+    this.setColorRange(visualization.colorRange);
+
+    if (visualization.elevationRange) {
+      this.setElevationRange(
+        visualization.elevationRange[0],
+        visualization.elevationRange[1]
+      );
+    } else {
+      this.clearElevationRange();
+    }
+
+    this.setPickable(visualization.pickable);
+    this.setZOffsetEnabled(visualization.zOffsetEnabled);
+    if (visualization.zOffsetEnabled) {
+      this.setZOffset(visualization.zOffset);
+    }
+    this.setTerrain(visualization.terrainEnabled);
+    this._panelBuilder?.updateState(this._state);
+
+    if (payload.map) {
+      this._applyShareMapState(payload.map);
+    }
+
+    const loadedPointClouds: PointCloudInfo[] = [];
+    const previousAutoZoom = this._options.autoZoom;
+    this._options.autoZoom = false;
+    try {
+      for (const source of payload.pointClouds) {
+        loadedPointClouds.push(await this.loadPointCloud(source));
+      }
+    } finally {
+      this._options.autoZoom = previousAutoZoom;
+    }
+
+    const hiddenClassifications = new Set(visualization.hiddenClassifications);
+    this._pointCloudManager?.setHiddenClassifications(hiddenClassifications);
+    this.setState({ hiddenClassifications });
+    this._emit('stylechange');
+
+    if (payload.map) {
+      this._applyShareMapState(payload.map);
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => this._applyShareMapState(payload.map!));
+      }
+      globalThis.setTimeout(() => this._applyShareMapState(payload.map!), 250);
+      globalThis.setTimeout(() => this._applyShareMapState(payload.map!), 1250);
+    }
+
+    return loadedPointClouds;
+  }
+
+  /**
    * Updates the control state.
    *
    * @param newState - Partial state to merge with current state
@@ -289,6 +389,9 @@ export class LidarControl implements IControl {
   setState(newState: Partial<LidarState>): void {
     this._state = { ...this._state, ...newState };
     this._panelBuilder?.updateState(this._state);
+    if (!this._state.collapsed) {
+      this._updatePanelPosition();
+    }
     this._emit('statechange');
   }
 
@@ -1860,6 +1963,47 @@ export class LidarControl implements IControl {
   // ==================== Private Methods ====================
 
   /**
+   * Gets the current map camera state for share URLs.
+   */
+  private _getShareMapState():
+    | {
+        center: [number, number];
+        zoom: number;
+        bearing: number;
+        pitch: number;
+      }
+    | undefined {
+    if (!this._map) return undefined;
+
+    const center = this._map.getCenter();
+    return {
+      center: [center.lng, center.lat],
+      zoom: this._map.getZoom(),
+      bearing: this._map.getBearing(),
+      pitch: this._map.getPitch(),
+    };
+  }
+
+  /**
+   * Applies a shared camera state to the map.
+   */
+  private _applyShareMapState(mapState: {
+    center: [number, number];
+    zoom: number;
+    bearing: number;
+    pitch: number;
+  }): void {
+    if (!this._map) return;
+
+    this._map.jumpTo({
+      center: mapState.center,
+      zoom: mapState.zoom,
+      bearing: mapState.bearing,
+      pitch: mapState.pitch,
+    });
+  }
+
+  /**
    * Emits an event to all registered handlers.
    *
    * @param event - The event type to emit
@@ -2036,6 +2180,7 @@ export class LidarControl implements IControl {
         onTerrainChange: (enabled) => this.setTerrain(enabled),
         onShowMetadata: (id) => this.showMetadataPanel(id),
         onCrossSectionPanel: () => this.getCrossSectionPanel().render(),
+        onShareUrl: this._options.shareUrl ? () => this.getShareUrl() : undefined,
       },
       this._state
     );
@@ -2416,6 +2561,7 @@ export class LidarControl implements IControl {
     const buttonRight = mapRect.right - buttonRect.right;
 
     const panelGap = 5; // Gap between button and panel
+    let availableHeight = mapRect.height - panelGap * 2;
 
     // Reset all positioning
     this._panel.style.top = '';
@@ -2428,25 +2574,44 @@ export class LidarControl implements IControl {
         // Panel expands down and to the right
         this._panel.style.top = `${buttonTop + buttonRect.height + panelGap}px`;
         this._panel.style.left = `${buttonLeft}px`;
+        availableHeight = mapRect.height - (buttonTop + buttonRect.height + panelGap) - panelGap;
         break;
 
       case 'top-right':
         // Panel expands down and to the left
         this._panel.style.top = `${buttonTop + buttonRect.height + panelGap}px`;
         this._panel.style.right = `${buttonRight}px`;
+        availableHeight = mapRect.height - (buttonTop + buttonRect.height + panelGap) - panelGap;
         break;
 
       case 'bottom-left':
         // Panel expands up and to the right
         this._panel.style.bottom = `${buttonBottom + buttonRect.height + panelGap}px`;
         this._panel.style.left = `${buttonLeft}px`;
+        availableHeight = mapRect.height - (buttonBottom + buttonRect.height + panelGap) - panelGap;
         break;
 
       case 'bottom-right':
         // Panel expands up and to the left
         this._panel.style.bottom = `${buttonBottom + buttonRect.height + panelGap}px`;
         this._panel.style.right = `${buttonRight}px`;
+        availableHeight = mapRect.height - (buttonBottom + buttonRect.height + panelGap) - panelGap;
         break;
+    }
+
+    const panelMaxHeight = Math.max(220, availableHeight);
+    this._panel.style.maxHeight = `${panelMaxHeight}px`;
+
+    const header = this._panel.querySelector('.lidar-control-header') as HTMLElement | null;
+    const content = this._panel.querySelector('.lidar-control-content') as HTMLElement | null;
+    if (content) {
+      const headerHeight = header?.offsetHeight ?? 0;
+      const panelPadding = 16;
+      const contentMaxHeight = Math.max(
+        180,
+        Math.min(this._state.maxHeight, panelMaxHeight - headerHeight - panelPadding)
+      );
+      content.style.maxHeight = `${contentMaxHeight}px`;
     }
   }
 

--- a/src/lib/core/LidarControlReact.tsx
+++ b/src/lib/core/LidarControlReact.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { LidarControl } from './LidarControl';
 import type { LidarControlReactProps } from './types';
+import { hasLidarShareParams } from '../utils/share-url';
 
 /**
  * React wrapper component for LidarControl.
@@ -85,7 +86,12 @@ export function LidarControlReact({
     }
 
     // Load default URL if provided
-    if (defaultUrl) {
+    const hasShareUrl =
+      typeof window !== 'undefined' &&
+      options.restoreFromUrl !== false &&
+      hasLidarShareParams(window.location.href);
+
+    if (defaultUrl && !hasShareUrl) {
       control.loadPointCloud(defaultUrl).catch((err) => {
         console.error('Failed to load default URL:', err);
       });

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -234,6 +234,18 @@ export interface LidarControlOptions {
   terrainEnabled?: boolean;
 
   /**
+   * Whether to show a Share URL button in the panel
+   * @default true
+   */
+  shareUrl?: boolean;
+
+  /**
+   * Whether to restore LiDAR state from share URL query parameters on add
+   * @default true
+   */
+  restoreFromUrl?: boolean;
+
+  /**
    * Terrain exaggeration factor (1.0 = actual elevation)
    * @default 1.0
    */

--- a/src/lib/gui/PanelBuilder.ts
+++ b/src/lib/gui/PanelBuilder.ts
@@ -32,6 +32,7 @@ export interface PanelBuilderCallbacks {
   onClassificationHideAll: () => void;
   onShowMetadata?: (id: string) => void;
   onCrossSectionPanel?: () => HTMLElement | null;
+  onShareUrl?: () => string;
 }
 
 /**
@@ -69,6 +70,7 @@ export class PanelBuilder {
   private _errorMessage?: HTMLElement;
   private _classificationLegend?: ClassificationLegend;
   private _classificationLegendContainer?: HTMLElement;
+  private _shareFeedbackTimeout?: ReturnType<typeof setTimeout>;
 
   constructor(callbacks: PanelBuilderCallbacks, initialState: LidarState) {
     this._callbacks = callbacks;
@@ -109,6 +111,11 @@ export class PanelBuilder {
 
     // Error message
     content.appendChild(this._buildErrorMessage());
+
+    const shareSection = this._buildShareSection();
+    if (shareSection) {
+      content.appendChild(shareSection);
+    }
 
     return content;
   }
@@ -979,6 +986,82 @@ export class PanelBuilder {
     error.style.display = 'none';
     this._errorMessage = error;
     return error;
+  }
+
+  /**
+   * Builds the share URL button section if sharing is enabled.
+   */
+  private _buildShareSection(): HTMLElement | null {
+    if (!this._callbacks.onShareUrl) return null;
+
+    const section = document.createElement('div');
+    section.className = 'lidar-control-section lidar-share-section';
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'lidar-control-button lidar-share-button';
+    button.textContent = 'Share URL';
+
+    const status = document.createElement('div');
+    status.className = 'lidar-share-status';
+    status.setAttribute('aria-live', 'polite');
+
+    button.addEventListener('click', async () => {
+      try {
+        const url = this._callbacks.onShareUrl?.();
+        if (!url) {
+          throw new Error('No share URL available');
+        }
+        await this._copyToClipboard(url);
+        this._setShareStatus(status, 'Copied');
+      } catch {
+        this._setShareStatus(status, 'Copy failed');
+      }
+    });
+
+    section.appendChild(button);
+    section.appendChild(status);
+
+    return section;
+  }
+
+  /**
+   * Copies text to the clipboard, falling back to a hidden textarea for older browsers.
+   */
+  private async _copyToClipboard(text: string): Promise<void> {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    textarea.style.top = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    const copied = document.execCommand('copy');
+    textarea.remove();
+
+    if (!copied) {
+      throw new Error('Clipboard copy failed');
+    }
+  }
+
+  /**
+   * Shows short share button feedback.
+   */
+  private _setShareStatus(status: HTMLElement, message: string): void {
+    status.textContent = message;
+    if (this._shareFeedbackTimeout) {
+      clearTimeout(this._shareFeedbackTimeout);
+    }
+    this._shareFeedbackTimeout = setTimeout(() => {
+      status.textContent = '';
+    }, 2000);
   }
 
   /**

--- a/src/lib/styles/lidar-control.css
+++ b/src/lib/styles/lidar-control.css
@@ -302,6 +302,28 @@
   background: #e0e0e0;
 }
 
+.lidar-share-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  background: #fff;
+  padding-top: 10px;
+}
+
+.lidar-share-button {
+  width: 100%;
+}
+
+.lidar-share-status {
+  min-height: 16px;
+  color: #555;
+  font-size: 11px;
+  text-align: center;
+}
+
 /* File input styling */
 .lidar-file-input-wrapper {
   position: relative;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -9,3 +9,20 @@ export {
   formatBytes,
   getFilename,
 } from './helpers';
+
+export {
+  LIDAR_SHARE_PARAM,
+  LIDAR_SHARE_VERSION,
+  createLidarSharePayload,
+  encodeLidarSharePayload,
+  decodeLidarSharePayload,
+  createLidarShareUrl,
+  parseLidarSharePayloadFromUrl,
+  hasLidarShareParams,
+} from './share-url';
+
+export type {
+  LidarShareMapState,
+  LidarShareVisualization,
+  LidarSharePayload,
+} from './share-url';

--- a/src/lib/utils/share-url.ts
+++ b/src/lib/utils/share-url.ts
@@ -1,0 +1,405 @@
+import type {
+  ColorRangeConfig,
+  ColorScheme,
+  ColormapName,
+  LidarState,
+} from '../core/types';
+
+export const LIDAR_SHARE_PARAM = 'lidar';
+export const LIDAR_SHARE_VERSION = 1;
+const LEGACY_URL_PARAM = 'url';
+const FLAT_SHARE_PARAMS = [
+  'url',
+  'lon',
+  'lat',
+  'zoom',
+  'bearing',
+  'pitch',
+  'size',
+  'opacity',
+  'color',
+  'cmap',
+  'range',
+  'plow',
+  'phigh',
+  'amin',
+  'amax',
+  'emin',
+  'emax',
+  'pick',
+  'zoff',
+  'zoffEnabled',
+  'terrain',
+  'hidden',
+];
+
+export interface LidarShareMapState {
+  center: [number, number];
+  zoom: number;
+  bearing: number;
+  pitch: number;
+}
+
+export interface LidarShareVisualization {
+  pointSize: number;
+  opacity: number;
+  colorScheme: ColorScheme;
+  colormap: ColormapName;
+  colorRange: ColorRangeConfig;
+  elevationRange: [number, number] | null;
+  pickable: boolean;
+  zOffsetEnabled: boolean;
+  zOffset: number;
+  terrainEnabled: boolean;
+  hiddenClassifications: number[];
+}
+
+export interface LidarSharePayload {
+  v: typeof LIDAR_SHARE_VERSION;
+  map?: LidarShareMapState;
+  pointClouds: string[];
+  visualization: LidarShareVisualization;
+}
+
+function encodeBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    const chunk = bytes.subarray(i, i + 0x8000);
+    binary += String.fromCharCode(...chunk);
+  }
+
+  const base64 =
+    typeof btoa === 'function'
+      ? btoa(binary)
+      : Buffer.from(bytes).toString('base64');
+
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function decodeBase64Url(value: string): string {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+
+  if (typeof atob === 'function') {
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return new TextDecoder().decode(bytes);
+  }
+
+  return Buffer.from(padded, 'base64').toString('utf-8');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isMapState(value: unknown): value is LidarShareMapState {
+  if (!isRecord(value)) return false;
+
+  const center = value.center;
+  return (
+    Array.isArray(center) &&
+    center.length === 2 &&
+    center.every(isNumber) &&
+    isNumber(value.zoom) &&
+    isNumber(value.bearing) &&
+    isNumber(value.pitch)
+  );
+}
+
+function isElevationRange(value: unknown): value is [number, number] | null {
+  return (
+    value === null ||
+    (Array.isArray(value) &&
+      value.length === 2 &&
+      isNumber(value[0]) &&
+      isNumber(value[1]))
+  );
+}
+
+function isColorRange(value: unknown): value is ColorRangeConfig {
+  if (!isRecord(value)) return false;
+  if (value.mode !== 'percentile' && value.mode !== 'absolute') return false;
+  if (!isNumber(value.percentileLow) || !isNumber(value.percentileHigh)) return false;
+  if (value.absoluteMin !== undefined && !isNumber(value.absoluteMin)) return false;
+  if (value.absoluteMax !== undefined && !isNumber(value.absoluteMax)) return false;
+  return true;
+}
+
+function isVisualization(value: unknown): value is LidarShareVisualization {
+  if (!isRecord(value)) return false;
+
+  return (
+    isNumber(value.pointSize) &&
+    isNumber(value.opacity) &&
+    value.colorScheme !== undefined &&
+    typeof value.colormap === 'string' &&
+    isColorRange(value.colorRange) &&
+    isElevationRange(value.elevationRange) &&
+    typeof value.pickable === 'boolean' &&
+    typeof value.zOffsetEnabled === 'boolean' &&
+    isNumber(value.zOffset) &&
+    typeof value.terrainEnabled === 'boolean' &&
+    Array.isArray(value.hiddenClassifications) &&
+    value.hiddenClassifications.every(isNumber)
+  );
+}
+
+function normalizePointCloudSource(source: string, baseUrl?: string): string | null {
+  if (!source || source === 'file') return null;
+
+  if (!baseUrl) return source;
+
+  try {
+    return new URL(source, baseUrl).toString();
+  } catch {
+    return source;
+  }
+}
+
+export function createLidarSharePayload(
+  state: LidarState,
+  map?: LidarShareMapState,
+  baseUrl?: string
+): LidarSharePayload {
+  const sources = new Set<string>();
+
+  for (const pointCloud of state.pointClouds) {
+    const source = normalizePointCloudSource(pointCloud.source, baseUrl);
+    if (source) {
+      sources.add(source);
+    }
+  }
+
+  return {
+    v: LIDAR_SHARE_VERSION,
+    map,
+    pointClouds: Array.from(sources),
+    visualization: {
+      pointSize: state.pointSize,
+      opacity: state.opacity,
+      colorScheme: state.colorScheme,
+      colormap: state.colormap,
+      colorRange: state.colorRange,
+      elevationRange: state.elevationRange,
+      pickable: state.pickable,
+      zOffsetEnabled: state.zOffsetEnabled,
+      zOffset: state.zOffset,
+      terrainEnabled: state.terrainEnabled,
+      hiddenClassifications: Array.from(state.hiddenClassifications).sort((a, b) => a - b),
+    },
+  };
+}
+
+export function encodeLidarSharePayload(payload: LidarSharePayload): string {
+  return encodeBase64Url(JSON.stringify(payload));
+}
+
+export function decodeLidarSharePayload(value: string): LidarSharePayload | null {
+  try {
+    const payload = JSON.parse(decodeBase64Url(value)) as unknown;
+    if (!isRecord(payload)) return null;
+    if (payload.v !== LIDAR_SHARE_VERSION) return null;
+    if (!Array.isArray(payload.pointClouds) || !payload.pointClouds.every((source) => typeof source === 'string')) {
+      return null;
+    }
+    if (!isVisualization(payload.visualization)) return null;
+    if (payload.map !== undefined && !isMapState(payload.map)) return null;
+
+    return {
+      v: LIDAR_SHARE_VERSION,
+      map: payload.map,
+      pointClouds: [...payload.pointClouds],
+      visualization: {
+        ...payload.visualization,
+        hiddenClassifications: [...payload.visualization.hiddenClassifications],
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function createLidarShareUrl(currentUrl: string, payload: LidarSharePayload): string {
+  const url = new URL(currentUrl);
+  for (const param of FLAT_SHARE_PARAMS) {
+    url.searchParams.delete(param);
+  }
+  url.searchParams.delete(LIDAR_SHARE_PARAM);
+
+  for (const source of payload.pointClouds) {
+    url.searchParams.append(LEGACY_URL_PARAM, source);
+  }
+
+  if (payload.map) {
+    url.searchParams.set('lon', formatQueryNumber(payload.map.center[0]));
+    url.searchParams.set('lat', formatQueryNumber(payload.map.center[1]));
+    url.searchParams.set('zoom', formatQueryNumber(payload.map.zoom));
+    url.searchParams.set('bearing', formatQueryNumber(payload.map.bearing));
+    url.searchParams.set('pitch', formatQueryNumber(payload.map.pitch));
+  }
+
+  const visualization = payload.visualization;
+  url.searchParams.set('size', formatQueryNumber(visualization.pointSize));
+  url.searchParams.set('opacity', formatQueryNumber(visualization.opacity));
+  url.searchParams.set(
+    'color',
+    typeof visualization.colorScheme === 'string'
+      ? visualization.colorScheme
+      : JSON.stringify(visualization.colorScheme)
+  );
+  url.searchParams.set('cmap', visualization.colormap);
+  url.searchParams.set('range', visualization.colorRange.mode);
+  url.searchParams.set('plow', formatQueryNumber(visualization.colorRange.percentileLow));
+  url.searchParams.set('phigh', formatQueryNumber(visualization.colorRange.percentileHigh));
+  if (visualization.colorRange.absoluteMin !== undefined) {
+    url.searchParams.set('amin', formatQueryNumber(visualization.colorRange.absoluteMin));
+  }
+  if (visualization.colorRange.absoluteMax !== undefined) {
+    url.searchParams.set('amax', formatQueryNumber(visualization.colorRange.absoluteMax));
+  }
+  if (visualization.elevationRange) {
+    url.searchParams.set('emin', formatQueryNumber(visualization.elevationRange[0]));
+    url.searchParams.set('emax', formatQueryNumber(visualization.elevationRange[1]));
+  }
+  url.searchParams.set('pick', formatQueryBoolean(visualization.pickable));
+  url.searchParams.set('zoffEnabled', formatQueryBoolean(visualization.zOffsetEnabled));
+  url.searchParams.set('zoff', formatQueryNumber(visualization.zOffset));
+  url.searchParams.set('terrain', formatQueryBoolean(visualization.terrainEnabled));
+  if (visualization.hiddenClassifications.length > 0) {
+    url.searchParams.set('hidden', visualization.hiddenClassifications.join(','));
+  }
+  url.hash = '';
+  return url.toString();
+}
+
+export function parseLidarSharePayloadFromUrl(url: string): LidarSharePayload | null {
+  try {
+    const parsed = new URL(url);
+    const flatPayload = parseFlatLidarSharePayload(parsed.searchParams);
+    if (flatPayload) return flatPayload;
+
+    const value = parsed.searchParams.get(LIDAR_SHARE_PARAM);
+    return value ? decodeLidarSharePayload(value) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function hasLidarShareParams(url: string): boolean {
+  try {
+    const params = new URL(url).searchParams;
+    if (params.has(LIDAR_SHARE_PARAM)) return true;
+    return hasFlatLidarShareParams(params);
+  } catch {
+    return false;
+  }
+}
+
+function formatQueryNumber(value: number): string {
+  return Number.isInteger(value)
+    ? String(value)
+    : Number(value.toFixed(8)).toString();
+}
+
+function formatQueryBoolean(value: boolean): string {
+  return value ? '1' : '0';
+}
+
+function parseQueryNumber(value: string | null): number | undefined {
+  if (value === null || value.trim() === '') return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseQueryBoolean(value: string | null, fallback: boolean): boolean {
+  if (value === null) return fallback;
+  return value === '1' || value.toLowerCase() === 'true';
+}
+
+function parseColorScheme(value: string | null): ColorScheme {
+  if (!value) return 'elevation';
+  if (value.trim().startsWith('{')) {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (isRecord(parsed) && (parsed.type === 'gradient' || parsed.type === 'categorical') && typeof parsed.attribute === 'string') {
+        return parsed as unknown as ColorScheme;
+      }
+    } catch {
+      return 'elevation';
+    }
+  }
+  return value as ColorScheme;
+}
+
+function hasFlatLidarShareParams(params: URLSearchParams): boolean {
+  return FLAT_SHARE_PARAMS.some((param) => param !== LEGACY_URL_PARAM && params.has(param));
+}
+
+function parseFlatLidarSharePayload(params: URLSearchParams): LidarSharePayload | null {
+  if (!hasFlatLidarShareParams(params)) return null;
+
+  const lon = parseQueryNumber(params.get('lon'));
+  const lat = parseQueryNumber(params.get('lat'));
+  const zoom = parseQueryNumber(params.get('zoom'));
+  const bearing = parseQueryNumber(params.get('bearing')) ?? 0;
+  const pitch = parseQueryNumber(params.get('pitch')) ?? 0;
+  const pointSize = parseQueryNumber(params.get('size')) ?? 2;
+  const opacity = parseQueryNumber(params.get('opacity')) ?? 1;
+  const percentileLow = parseQueryNumber(params.get('plow')) ?? 2;
+  const percentileHigh = parseQueryNumber(params.get('phigh')) ?? 98;
+  const absoluteMin = parseQueryNumber(params.get('amin'));
+  const absoluteMax = parseQueryNumber(params.get('amax'));
+  const elevationMin = parseQueryNumber(params.get('emin'));
+  const elevationMax = parseQueryNumber(params.get('emax'));
+  const zOffset = parseQueryNumber(params.get('zoff')) ?? 0;
+  const hiddenClassifications = (params.get('hidden') ?? '')
+    .split(',')
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value));
+
+  return {
+    v: LIDAR_SHARE_VERSION,
+    map:
+      lon !== undefined && lat !== undefined && zoom !== undefined
+        ? {
+            center: [lon, lat],
+            zoom,
+            bearing,
+            pitch,
+          }
+        : undefined,
+    pointClouds: params.getAll(LEGACY_URL_PARAM).filter((source) => source.trim() !== ''),
+    visualization: {
+      pointSize,
+      opacity,
+      colorScheme: parseColorScheme(params.get('color')),
+      colormap: (params.get('cmap') ?? 'viridis') as ColormapName,
+      colorRange: {
+        mode: params.get('range') === 'absolute' ? 'absolute' : 'percentile',
+        percentileLow,
+        percentileHigh,
+        ...(absoluteMin !== undefined ? { absoluteMin } : {}),
+        ...(absoluteMax !== undefined ? { absoluteMax } : {}),
+      },
+      elevationRange:
+        elevationMin !== undefined && elevationMax !== undefined
+          ? [elevationMin, elevationMax]
+          : null,
+      pickable: parseQueryBoolean(params.get('pick'), false),
+      zOffsetEnabled: parseQueryBoolean(params.get('zoffEnabled'), false),
+      zOffset,
+      terrainEnabled: parseQueryBoolean(params.get('terrain'), false),
+      hiddenClassifications,
+    },
+  };
+}

--- a/tests/panel-share.test.ts
+++ b/tests/panel-share.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LidarState } from '../src/lib/core/types';
+import { PanelBuilder, type PanelBuilderCallbacks } from '../src/lib/gui/PanelBuilder';
+
+function createState(): LidarState {
+  return {
+    collapsed: false,
+    panelWidth: 365,
+    maxHeight: 500,
+    pointClouds: [],
+    activePointCloudId: null,
+    pointSize: 2,
+    opacity: 1,
+    colorScheme: 'elevation',
+    colormap: 'viridis',
+    colorRange: {
+      mode: 'percentile',
+      percentileLow: 2,
+      percentileHigh: 98,
+    },
+    showColorbar: true,
+    usePercentile: true,
+    elevationRange: null,
+    pointBudget: 1000000,
+    pickable: false,
+    loading: false,
+    error: null,
+    zOffsetEnabled: false,
+    zOffset: 0,
+    hiddenClassifications: new Set(),
+    availableClassifications: new Set(),
+    terrainEnabled: false,
+  };
+}
+
+function createCallbacks(overrides: Partial<PanelBuilderCallbacks> = {}): PanelBuilderCallbacks {
+  return {
+    onFileSelect: vi.fn(),
+    onUrlSubmit: vi.fn(),
+    onPointSizeChange: vi.fn(),
+    onOpacityChange: vi.fn(),
+    onColorSchemeChange: vi.fn(),
+    onColormapChange: vi.fn(),
+    onColorRangeChange: vi.fn(),
+    onUsePercentileChange: vi.fn(),
+    onElevationRangeChange: vi.fn(),
+    onPickableChange: vi.fn(),
+    onZOffsetEnabledChange: vi.fn(),
+    onZOffsetChange: vi.fn(),
+    onTerrainChange: vi.fn(),
+    onUnload: vi.fn(),
+    onZoomTo: vi.fn(),
+    onClassificationToggle: vi.fn(),
+    onClassificationShowAll: vi.fn(),
+    onClassificationHideAll: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('PanelBuilder share URL button', () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      value: vi.fn(() => ({
+        createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+        fillRect: vi.fn(),
+        fillStyle: '',
+      })),
+      configurable: true,
+    });
+  });
+
+  it('copies the share URL and shows success feedback', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const onShareUrl = vi.fn(() => 'https://example.com/viewer?lidar=abc');
+    const panel = new PanelBuilder(createCallbacks({ onShareUrl }), createState()).build();
+    const button = panel.querySelector('.lidar-share-button') as HTMLButtonElement;
+
+    button.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onShareUrl).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith('https://example.com/viewer?lidar=abc');
+    expect(panel.querySelector('.lidar-share-status')?.textContent).toBe('Copied');
+  });
+
+  it('shows failure feedback when clipboard copy fails', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+      configurable: true,
+    });
+
+    const panel = new PanelBuilder(
+      createCallbacks({ onShareUrl: () => 'https://example.com/viewer?lidar=abc' }),
+      createState()
+    ).build();
+    const button = panel.querySelector('.lidar-share-button') as HTMLButtonElement;
+
+    button.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(panel.querySelector('.lidar-share-status')?.textContent).toBe('Copy failed');
+  });
+});

--- a/tests/share-url.test.ts
+++ b/tests/share-url.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import type { LidarState } from '../src/lib/core/types';
+import {
+  LIDAR_SHARE_PARAM,
+  createLidarSharePayload,
+  createLidarShareUrl,
+  decodeLidarSharePayload,
+  encodeLidarSharePayload,
+  hasLidarShareParams,
+  parseLidarSharePayloadFromUrl,
+} from '../src/lib/utils/share-url';
+
+function createState(overrides: Partial<LidarState> = {}): LidarState {
+  return {
+    collapsed: false,
+    panelWidth: 365,
+    maxHeight: 500,
+    pointClouds: [
+      {
+        id: 'pc-1',
+        name: 'remote.copc.laz',
+        pointCount: 100,
+        bounds: {
+          minX: -123,
+          minY: 44,
+          maxX: -122,
+          maxY: 45,
+          minZ: 10,
+          maxZ: 120,
+        },
+        hasRGB: true,
+        hasIntensity: true,
+        hasClassification: true,
+        source: 'data/remote.copc.laz',
+      },
+      {
+        id: 'pc-2',
+        name: 'local.laz',
+        pointCount: 50,
+        bounds: {
+          minX: 0,
+          minY: 0,
+          maxX: 1,
+          maxY: 1,
+          minZ: 0,
+          maxZ: 1,
+        },
+        hasRGB: false,
+        hasIntensity: true,
+        hasClassification: false,
+        source: 'file',
+      },
+    ],
+    activePointCloudId: 'pc-1',
+    pointSize: 4,
+    opacity: 0.65,
+    colorScheme: 'classification',
+    colormap: 'turbo',
+    colorRange: {
+      mode: 'absolute',
+      percentileLow: 2,
+      percentileHigh: 98,
+      absoluteMin: 10,
+      absoluteMax: 90,
+    },
+    showColorbar: true,
+    usePercentile: true,
+    elevationRange: [20, 80],
+    pointBudget: 1000000,
+    pickable: true,
+    loading: false,
+    error: null,
+    zOffsetEnabled: true,
+    zOffset: -12,
+    hiddenClassifications: new Set([7, 2]),
+    availableClassifications: new Set([1, 2, 7]),
+    terrainEnabled: true,
+    ...overrides,
+  };
+}
+
+describe('share URL helpers', () => {
+  it('round-trips map and visualization settings', () => {
+    const payload = createLidarSharePayload(
+      createState(),
+      {
+        center: [-122.5, 44.5],
+        zoom: 12,
+        bearing: 15,
+        pitch: 60,
+      },
+      'https://example.com/viewer/index.html?foo=bar'
+    );
+
+    const decoded = decodeLidarSharePayload(encodeLidarSharePayload(payload));
+
+    expect(decoded).toEqual(payload);
+    expect(decoded?.pointClouds).toEqual([
+      'https://example.com/viewer/data/remote.copc.laz',
+    ]);
+    expect(decoded?.visualization.hiddenClassifications).toEqual([2, 7]);
+  });
+
+  it('creates readable query parameters and strips hash state', () => {
+    const payload = createLidarSharePayload(createState());
+    const url = createLidarShareUrl(
+      'https://example.com/viewer?foo=bar&url=https%3A%2F%2Fold.example%2Ffile.laz#12/44/-122',
+      payload
+    );
+    const parsed = new URL(url);
+
+    expect(parsed.searchParams.get('foo')).toBe('bar');
+    expect(parsed.searchParams.getAll('url')).toEqual(['data/remote.copc.laz']);
+    expect(parsed.searchParams.has(LIDAR_SHARE_PARAM)).toBe(false);
+    expect(parsed.searchParams.get('color')).toBe('classification');
+    expect(parsed.searchParams.get('cmap')).toBe('turbo');
+    expect(parsed.searchParams.get('zoff')).toBe('-12');
+    expect(parsed.hash).toBe('');
+    expect(parseLidarSharePayloadFromUrl(url)).toEqual(payload);
+    expect(hasLidarShareParams(url)).toBe(true);
+    expect(hasLidarShareParams('https://example.com/viewer?url=https://example.com/file.laz')).toBe(false);
+  });
+
+  it('rejects malformed payloads safely', () => {
+    expect(decodeLidarSharePayload('not-valid-base64')).toBeNull();
+    expect(parseLidarSharePayloadFromUrl('https://example.com/viewer')).toBeNull();
+
+    const url = new URL('https://example.com/viewer');
+    url.searchParams.set(LIDAR_SHARE_PARAM, encodeLidarSharePayload({
+      v: 1,
+      pointClouds: ['https://example.com/file.laz'],
+      visualization: {
+        pointSize: Number.NaN,
+        opacity: 1,
+        colorScheme: 'elevation',
+        colormap: 'viridis',
+        colorRange: { mode: 'percentile', percentileLow: 2, percentileHigh: 98 },
+        elevationRange: null,
+        pickable: false,
+        zOffsetEnabled: false,
+        zOffset: 0,
+        terrainEnabled: false,
+        hiddenClassifications: [],
+      },
+    }));
+
+    expect(parseLidarSharePayloadFromUrl(url.toString())).toBeNull();
+  });
+
+  it('omits non-shareable local file sources', () => {
+    const payload = createLidarSharePayload(createState({
+      pointClouds: [
+        {
+          id: 'pc-local',
+          name: 'local.laz',
+          pointCount: 1,
+          bounds: {
+            minX: 0,
+            minY: 0,
+            maxX: 0,
+            maxY: 0,
+            minZ: 0,
+            maxZ: 0,
+          },
+          hasRGB: false,
+          hasIntensity: false,
+          hasClassification: false,
+          source: 'file',
+        },
+      ],
+    }));
+
+    expect(payload.pointClouds).toEqual([]);
+  });
+});

--- a/viewer/main.ts
+++ b/viewer/main.ts
@@ -1,5 +1,5 @@
 import maplibregl from 'maplibre-gl';
-import { LidarControl, LidarLayerAdapter } from '../src/index';
+import { hasLidarShareParams, LidarControl, LidarLayerAdapter } from '../src/index';
 import { LayerControl } from 'maplibre-gl-layer-control';
 import '../src/index.css';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -11,6 +11,9 @@ const urlForm = document.getElementById('url-form') as HTMLFormElement;
 const urlInput = document.getElementById('url-input') as HTMLInputElement;
 const loadBtn = document.getElementById('load-btn') as HTMLButtonElement;
 const loadingIndicator = document.getElementById('loading-indicator') as HTMLDivElement;
+const params = new URLSearchParams(window.location.search);
+const initialUrl = params.get('url');
+const initialShareUrl = hasLidarShareParams(window.location.href);
 
 let map: maplibregl.Map | null = null;
 let lidarControl: LidarControl | null = null;
@@ -74,6 +77,7 @@ function initLidarControl(): LidarControl {
     pointSize: 2,
     opacity: 1.0,
     colorScheme: 'elevation',
+    restoreFromUrl: false,
   });
 
   return lidarControl;
@@ -161,6 +165,41 @@ async function loadPointCloud(url: string): Promise<void> {
   }
 }
 
+// Restore point cloud and visualization state from a shared URL
+async function restoreSharedLidarState(): Promise<void> {
+  loadingIndicator.style.display = 'block';
+  loadBtn.disabled = true;
+
+  try {
+    const mapInstance = initMap();
+
+    if (!mapInstance.loaded()) {
+      await new Promise<void>((resolve) => {
+        mapInstance.on('load', () => resolve());
+      });
+    }
+
+    const control = initLidarControl();
+    const lc = initLayerControl(control);
+    if (!mapInstance.hasControl(lc)) {
+      mapInstance.addControl(lc, 'top-right');
+    }
+    if (!mapInstance.hasControl(control)) {
+      mapInstance.addControl(control, 'top-right');
+    }
+
+    await control.restoreFromUrl(window.location.href);
+    urlFormContainer.style.display = 'none';
+  } catch (err) {
+    console.error('Failed to restore shared LiDAR state:', err);
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    alert(`Failed to restore shared LiDAR state: ${message}`);
+  } finally {
+    loadingIndicator.style.display = 'none';
+    loadBtn.disabled = false;
+  }
+}
+
 // Event listeners
 urlForm.addEventListener('submit', (e) => {
   e.preventDefault();
@@ -181,11 +220,9 @@ document.querySelectorAll('.sample-urls button[data-url]').forEach((btn) => {
   });
 });
 
-// Check for URL parameter on page load
-const params = new URLSearchParams(window.location.search);
-const initialUrl = params.get('url');
-
-if (initialUrl) {
+if (initialShareUrl) {
+  restoreSharedLidarState();
+} else if (initialUrl) {
   urlInput.value = initialUrl;
   loadPointCloud(initialUrl);
 }


### PR DESCRIPTION
## Summary
- Add `getShareUrl()` and `restoreFromUrl()` to `LidarControl` so URL-loaded point clouds, the map camera, and visualization settings can be captured in a single link.
- Add a Share URL button to the panel (toggleable via `shareUrl` / `restoreFromUrl` options) with copy-to-clipboard feedback, and wire restore-on-load through the React wrapper and the demo viewer.
- Use readable query parameters (`url`, `lon`, `lat`, `zoom`, `pitch`, `bearing`, `color`, `cmap`, `size`, `opacity`, `zoff`, etc.) and ship unit tests for the share-url codec and the panel button.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `npm test` (vitest: 27 tests pass, including new `tests/share-url.test.ts` and `tests/panel-share.test.ts`)
- [x] `npx tsc -p tsconfig.build.json --noEmit`
- [ ] Manually verify Share URL copy and restore in the viewer