### PR TITLE
feat: evict offscreen COPC nodes and manage point budget

### DIFF
--- a/src/lib/core/LidarControl.ts
+++ b/src/lib/core/LidarControl.ts
@@ -117,6 +117,7 @@ export class LidarControl implements IControl {
   private _streamingLoaders: Map<string, CopcStreamingLoader> = new Map();
   private _eptStreamingLoaders: Map<string, EptStreamingLoader> = new Map();
   private _viewportManagers: Map<string, ViewportManager> = new Map();
+  private _copcViewportRequestIds: Map<string, number> = new Map();
   private _eptViewportRequestIds: Map<string, number> = new Map();
   private _eptLastViewport: Map<string, ViewportInfo> = new Map();
 
@@ -936,6 +937,7 @@ export class LidarControl implements IControl {
           streamingLoader.destroy();
           this._streamingLoaders.delete(id);
         }
+        this._copcViewportRequestIds.delete(id);
         const viewportManager = this._viewportManagers.get(id);
         if (viewportManager) {
           viewportManager.destroy();
@@ -963,6 +965,12 @@ export class LidarControl implements IControl {
         streamingActive: false,
         error: `Failed to load: ${error.message}`,
       });
+      const streamingLoader = this._streamingLoaders.get(id);
+      if (streamingLoader) {
+        streamingLoader.destroy();
+        this._streamingLoaders.delete(id);
+      }
+      this._copcViewportRequestIds.delete(id);
       this._emitWithData('loaderror', { error });
       throw error;
     }
@@ -1477,15 +1485,53 @@ export class LidarControl implements IControl {
    */
   private async _handleViewportChangeForStreaming(
     viewport: ViewportInfo,
-    datasetId: string
+    datasetId: string,
+    requestId?: number
   ): Promise<void> {
     const streamingLoader = this._streamingLoaders.get(datasetId);
     if (!streamingLoader) return;
 
     try {
-      // Select nodes for this viewport
-      const nodesToLoad =
-        await streamingLoader.selectNodesForViewport(viewport);
+      const currentRequestId = requestId ?? (this._copcViewportRequestIds.get(datasetId) ?? 0) + 1;
+      if (requestId === undefined) {
+        this._copcViewportRequestIds.set(datasetId, currentRequestId);
+      }
+
+      if (this._copcViewportRequestIds.get(datasetId) !== currentRequestId) return;
+
+      streamingLoader.pruneQueueForViewport(viewport);
+
+      const evictSucceeded = streamingLoader.evictLoadedNodesOutsideViewport(viewport);
+      if (!evictSucceeded) {
+        setTimeout(() => {
+          this._handleViewportChangeForStreaming(viewport, datasetId, currentRequestId);
+        }, 200);
+        return;
+      }
+
+      let nodesToLoad = await streamingLoader.selectNodesForViewport(viewport);
+
+      if (this._copcViewportRequestIds.get(datasetId) !== currentRequestId) return;
+
+      let resetSucceeded = false;
+      const loadedPoints = streamingLoader.getLoadedPointCount();
+      const pointBudget = streamingLoader.getPointBudget();
+      const budgetReached = loadedPoints >= pointBudget * 0.8;
+      const minDepthForCoverage = Math.max(0, viewport.targetDepth - 2);
+      const coverageRatio = streamingLoader.getViewportCoverageRatio(viewport, minDepthForCoverage);
+      const needsCoverage = coverageRatio < 0.5;
+      const hasPendingWork = nodesToLoad.length > 0;
+
+      if (budgetReached && needsCoverage && hasPendingWork) {
+        resetSucceeded = streamingLoader.resetLoadedData();
+        if (!resetSucceeded) {
+          setTimeout(() => {
+            this._handleViewportChangeForStreaming(viewport, datasetId, currentRequestId);
+          }, 200);
+          return;
+        }
+        nodesToLoad = await streamingLoader.selectNodesForViewport(viewport);
+      }
 
       // Queue nodes for loading
       for (const node of nodesToLoad) {
@@ -1494,6 +1540,14 @@ export class LidarControl implements IControl {
 
       // Start loading
       await streamingLoader.loadQueuedNodes();
+
+      if (this._copcViewportRequestIds.get(datasetId) !== currentRequestId) return;
+
+      if (budgetReached && needsCoverage && nodesToLoad.length > 0 && !resetSucceeded) {
+        setTimeout(() => {
+          this._handleViewportChangeForStreaming(viewport, datasetId, currentRequestId);
+        }, 200);
+      }
     } catch (err) {
       console.warn('Failed to load nodes for viewport:', err);
     }
@@ -1519,6 +1573,7 @@ export class LidarControl implements IControl {
         streamingLoader.destroy();
         this._streamingLoaders.delete(id);
       }
+      this._copcViewportRequestIds.delete(id);
 
       // Check EPT streaming loader
       const eptLoader = this._eptStreamingLoaders.get(id);
@@ -1567,6 +1622,7 @@ export class LidarControl implements IControl {
         streamingLoader.destroy();
       }
       this._streamingLoaders.clear();
+      this._copcViewportRequestIds.clear();
 
       // Destroy all EPT streaming loaders
       for (const eptLoader of this._eptStreamingLoaders.values()) {

--- a/src/lib/core/LidarControl.ts
+++ b/src/lib/core/LidarControl.ts
@@ -1538,16 +1538,9 @@ export class LidarControl implements IControl {
         streamingLoader.queueNode(node);
       }
 
-      // Start loading
+      // Start loading. The loader self-drains its queue as each request
+      // completes, so no follow-up pass is needed here.
       await streamingLoader.loadQueuedNodes();
-
-      if (this._copcViewportRequestIds.get(datasetId) !== currentRequestId) return;
-
-      if (budgetReached && needsCoverage && nodesToLoad.length > 0 && !resetSucceeded) {
-        setTimeout(() => {
-          this._handleViewportChangeForStreaming(viewport, datasetId, currentRequestId);
-        }, 200);
-      }
     } catch (err) {
       console.warn('Failed to load nodes for viewport:', err);
     }

--- a/src/lib/layers/PointCloudManager.ts
+++ b/src/lib/layers/PointCloudManager.ts
@@ -19,6 +19,8 @@ interface ManagedPointCloud {
   visible: boolean;
   /** Per-layer opacity override (null means use global) */
   opacityOverride: number | null;
+  /** Number of deck.gl chunk layers currently created for this point cloud */
+  chunkCount: number;
 }
 
 /**
@@ -87,6 +89,7 @@ export class PointCloudManager {
       coordinateOrigin,
       visible: true,
       opacityOverride: null,
+      chunkCount: 0,
     });
     this._createLayer(id);
   }
@@ -99,12 +102,23 @@ export class PointCloudManager {
    * @param data - Updated point cloud data
    */
   updatePointCloud(id: string, data: PointCloudData): void {
-    // Skip update if no points to render
+    const existing = this._pointClouds.get(id);
+
     if (!data.positions || data.pointCount === 0) {
+      if (existing) {
+        this._pointClouds.set(id, {
+          id,
+          data,
+          colors: new Uint8Array(0),
+          coordinateOrigin: data.coordinateOrigin,
+          visible: existing.visible,
+          opacityOverride: existing.opacityOverride,
+          chunkCount: existing.chunkCount,
+        });
+        this._createLayer(id);
+      }
       return;
     }
-
-    const existing = this._pointClouds.get(id);
 
     if (existing) {
       // Recalculate colors for new data
@@ -127,6 +141,7 @@ export class PointCloudManager {
         coordinateOrigin: data.coordinateOrigin,
         visible: existing.visible,
         opacityOverride: existing.opacityOverride,
+        chunkCount: existing.chunkCount,
       });
 
       // Recreate layers with new data
@@ -156,9 +171,7 @@ export class PointCloudManager {
     const pc = this._pointClouds.get(id);
     if (pc) {
       // Remove all chunk layers
-      const CHUNK_SIZE = 1000000;
-      const numChunks = Math.ceil(pc.data.pointCount / CHUNK_SIZE);
-      for (let chunk = 0; chunk < numChunks; chunk++) {
+      for (let chunk = 0; chunk < pc.chunkCount; chunk++) {
         this._deckOverlay.removeLayer(`pointcloud-${id}-chunk${chunk}`);
       }
     }
@@ -393,9 +406,7 @@ export class PointCloudManager {
   clear(): void {
     for (const [id, pc] of this._pointClouds) {
       // Remove all chunk layers
-      const CHUNK_SIZE = 1000000;
-      const numChunks = Math.ceil(pc.data.pointCount / CHUNK_SIZE);
-      for (let chunk = 0; chunk < numChunks; chunk++) {
+      for (let chunk = 0; chunk < pc.chunkCount; chunk++) {
         this._deckOverlay.removeLayer(`pointcloud-${id}-chunk${chunk}`);
       }
     }
@@ -505,14 +516,14 @@ export class PointCloudManager {
     const zOffset = this._options.zOffset ?? 0;
     const layerOpacity = opacityOverride ?? this._options.opacity;
 
-    // Remove existing chunk layers first (use a generous upper bound)
-    const maxPossibleChunks = Math.ceil(data.pointCount / 1000000) + 1;
-    for (let chunk = 0; chunk < maxPossibleChunks; chunk++) {
+    // Remove existing chunk layers first.
+    for (let chunk = 0; chunk < pc.chunkCount; chunk++) {
       this._deckOverlay.removeLayer(`pointcloud-${id}-chunk${chunk}`);
     }
 
     // If layer is not visible, don't create any layers
     if (!visible) {
+      this._pointClouds.set(id, { ...pc, chunkCount: 0 });
       return;
     }
 
@@ -529,6 +540,7 @@ export class PointCloudManager {
 
     // If no points pass the filter, don't create any layers
     if (filteredIndices.length === 0) {
+      this._pointClouds.set(id, { ...pc, chunkCount: 0 });
       return;
     }
 
@@ -641,6 +653,8 @@ export class PointCloudManager {
 
       this._deckOverlay.addLayer(`pointcloud-${id}-chunk${chunk}`, layer);
     }
+
+    this._pointClouds.set(id, { ...pc, chunkCount: numChunks });
   }
 
   /**

--- a/src/lib/loaders/CopcStreamingLoader.ts
+++ b/src/lib/loaders/CopcStreamingLoader.ts
@@ -749,6 +749,126 @@ export class CopcStreamingLoader {
   }
 
   /**
+   * Removes queued nodes that are outside the current viewport and re-sorts priorities.
+   *
+   * @param viewport - Current viewport information
+   */
+  pruneQueueForViewport(viewport: ViewportInfo): void {
+    if (this._loadingQueue.length === 0) return;
+
+    this._loadingQueue = this._loadingQueue.filter((node) =>
+      this._boundsIntersectsViewport(node.boundsWgs84, viewport)
+    );
+
+    for (const node of this._loadingQueue) {
+      const distPriority = this._calculateNodePriority(node.boundsWgs84, viewport);
+      const depth = node.keyArray[0];
+      node.priority = distPriority - (depth * 0.0001);
+    }
+
+    this._loadingQueue.sort((a, b) => (a.priority || Infinity) - (b.priority || Infinity));
+  }
+
+  /**
+   * Evicts loaded nodes outside the current viewport and compacts point buffers.
+   * Hierarchy metadata is kept so evicted nodes can be loaded again later.
+   *
+   * @param viewport - Current viewport information
+   * @returns True if eviction completed, or false if active requests are still writing buffers
+   */
+  evictLoadedNodesOutsideViewport(viewport: ViewportInfo): boolean {
+    if (this._activeRequests > 0) return false;
+
+    const loadedNodes = Array.from(this._nodeCache.values())
+      .filter((node) => node.state === 'loaded' && node.bufferStartIndex !== undefined);
+    if (loadedNodes.length === 0) return true;
+
+    const keepNodes = loadedNodes
+      .filter((node) => this._boundsIntersectsViewport(node.boundsWgs84, viewport))
+      .sort((a, b) => a.bufferStartIndex! - b.bufferStartIndex!);
+    const keepNodeKeys = new Set(keepNodes.map((node) => node.key));
+
+    let nextStart = 0;
+    for (const node of keepNodes) {
+      const oldStart = node.bufferStartIndex!;
+      if (oldStart !== nextStart) {
+        this._copyNodeBufferRange(oldStart, nextStart, node.pointCount);
+      }
+      node.bufferStartIndex = nextStart;
+      nextStart += node.pointCount;
+    }
+
+    let evictedCount = 0;
+    for (const node of this._nodeCache.values()) {
+      if (node.state === 'loaded' && keepNodeKeys.has(node.key)) continue;
+      if (node.state !== 'loaded' && node.state !== 'error') continue;
+
+      node.state = 'pending';
+      node.bufferStartIndex = undefined;
+      node.error = undefined;
+      node.priority = undefined;
+      evictedCount++;
+    }
+
+    const pointsChanged = nextStart !== this._totalLoadedPoints;
+    if (evictedCount > 0 || pointsChanged) {
+      this._totalLoadedPoints = nextStart;
+      this._totalLoadedNodes = keepNodes.length;
+      this._emit('progress', this._getProgressEvent());
+      this._scheduleLayerUpdate();
+    }
+
+    return true;
+  }
+
+  /**
+   * Resets loaded node data while retaining the COPC hierarchy cache.
+   *
+   * @returns True if reset completed, or false if active requests are still writing buffers
+   */
+  resetLoadedData(): boolean {
+    if (this._activeRequests > 0) return false;
+
+    this._loadingQueue = [];
+    this._totalLoadedPoints = 0;
+    this._totalLoadedNodes = 0;
+
+    for (const node of this._nodeCache.values()) {
+      if (node.state === 'loaded' || node.state === 'loading' || node.state === 'error') {
+        node.state = 'pending';
+        node.bufferStartIndex = undefined;
+        node.error = undefined;
+        node.priority = undefined;
+      }
+    }
+
+    this._emit('progress', this._getProgressEvent());
+    this._scheduleLayerUpdate();
+    return true;
+  }
+
+  /**
+   * Copies a node's point data from one buffer range to another.
+   *
+   * @param fromStart - Source point index
+   * @param toStart - Destination point index
+   * @param pointCount - Number of points to copy
+   */
+  private _copyNodeBufferRange(fromStart: number, toStart: number, pointCount: number): void {
+    this._positions!.copyWithin(toStart * 3, fromStart * 3, (fromStart + pointCount) * 3);
+    this._intensities!.copyWithin(toStart, fromStart, fromStart + pointCount);
+    this._classifications!.copyWithin(toStart, fromStart, fromStart + pointCount);
+
+    if (this._colors) {
+      this._colors.copyWithin(toStart * 4, fromStart * 4, (fromStart + pointCount) * 4);
+    }
+
+    for (const arr of Object.values(this._extraAttributes)) {
+      arr.copyWithin(toStart, fromStart, fromStart + pointCount);
+    }
+  }
+
+  /**
    * Loads a single node's point data.
    *
    * @param node - Node to load
@@ -1026,6 +1146,46 @@ export class CopcStreamingLoader {
    */
   getLoadedPointCount(): number {
     return this._totalLoadedPoints;
+  }
+
+  /**
+   * Gets the configured point budget.
+   *
+   * @returns Maximum point count for the streaming buffers
+   */
+  getPointBudget(): number {
+    return this._options.pointBudget;
+  }
+
+  /**
+   * Estimates viewport coverage ratio by loaded nodes.
+   *
+   * @param viewport - Current viewport information
+   * @param minDepth - Minimum octree depth to consider
+   * @returns Coverage ratio from 0 to 1
+   */
+  getViewportCoverageRatio(viewport: ViewportInfo, minDepth: number = 0): number {
+    const [west, south, east, north] = viewport.bounds;
+    const viewportArea = (east - west) * (north - south);
+    if (viewportArea <= 0) return 0;
+
+    let coveredArea = 0;
+
+    for (const node of this._nodeCache.values()) {
+      if (node.state !== 'loaded') continue;
+      if (node.keyArray[0] < minDepth) continue;
+
+      const intersectWest = Math.max(west, node.boundsWgs84.minX);
+      const intersectEast = Math.min(east, node.boundsWgs84.maxX);
+      const intersectSouth = Math.max(south, node.boundsWgs84.minY);
+      const intersectNorth = Math.min(north, node.boundsWgs84.maxY);
+
+      if (intersectWest < intersectEast && intersectSouth < intersectNorth) {
+        coveredArea += (intersectEast - intersectWest) * (intersectNorth - intersectSouth);
+      }
+    }
+
+    return Math.min(1.0, coveredArea / viewportArea);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add viewport-aware node eviction and budget-driven resets to the COPC streaming loader so panning reclaims buffer space instead of stalling once the point budget fills.
- Track per-dataset request ids to cancel stale viewport updates and clean up streaming loaders on load failure.
- Fix chunk layer cleanup in PointCloudManager by recording the actual chunk count per point cloud rather than estimating from point counts.

## Test plan
- [ ] Load a large COPC dataset and pan across it; confirm new areas stream in and offscreen nodes are evicted without stalling.
- [ ] Verify the point budget cap is respected and coverage resets trigger when needed.
- [ ] Toggle layer visibility and remove/clear point clouds; confirm all chunk layers are removed with no orphans.
- [ ] Trigger a load error and confirm the streaming loader is cleaned up.