### PR TITLE
Dark theme support and resizable full-height panel (v0.16.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,9 @@ interface LidarControlOptions {
   collapsed?: boolean; // Start collapsed (default: true)
   position?: string; // 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
   title?: string; // Panel title (default: 'LiDAR Viewer')
-  panelWidth?: number; // Panel width in pixels (default: 365)
+  panelWidth?: number; // Initial panel width in pixels (default: 365)
   panelMaxHeight?: number; // Panel max height with scrollbar (default: 500)
+  theme?: 'auto' | 'light' | 'dark'; // Color theme (default: 'auto', follows OS)
   className?: string; // Custom CSS class
 
   // Point cloud styling
@@ -318,6 +319,10 @@ hideAllClassifications(): void
 getHiddenClassifications(): number[]
 getAvailableClassifications(): number[]
 
+// Theme
+setTheme(theme: 'auto' | 'light' | 'dark'): void
+getTheme(): 'auto' | 'light' | 'dark'
+
 // Panel control
 toggle(): void
 expand(): void
@@ -333,6 +338,22 @@ getMap(): MapLibreMap | undefined
 ```
 
 Share URLs use readable query parameters such as `url`, `lon`, `lat`, `zoom`, `pitch`, `bearing`, `color`, `cmap`, `size`, `opacity`, and `zoff`.
+
+#### Theming
+
+The control adapts to light and dark themes. By default (`theme: 'auto'`) it follows the operating system / browser `prefers-color-scheme` setting. Set `theme: 'dark'` or `theme: 'light'` to force a theme, which is handy when pairing the control with a dark basemap, and call `setTheme(...)` to switch at runtime:
+
+```typescript
+const control = new LidarControl({ theme: 'dark' });
+// later
+control.setTheme('auto');
+```
+
+All colors are driven by `--lidar-*` CSS custom properties, so you can override individual tokens (or the whole palette) in your own stylesheet. Forced themes add a `lidar-theme-dark` / `lidar-theme-light` class to the `<html>` element so panels and modals rendered at the document root inherit the theme too.
+
+#### Resizable panel
+
+The panel can be resized by dragging the grip in its free bottom corner (bottom-left for right-anchored positions, bottom-right for left-anchored positions). It expands to use the available vertical space and shows a vertical scrollbar only when the content overflows.
 
 #### Events
 

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -42,7 +42,7 @@
   <div id="map"></div>
   <div class="info-box">
     <h3>LiDAR Point Cloud Viewer</h3>
-    <p>Click the point cloud icon in the top-right corner to open the control panel. You can load LAS/LAZ files and adjust styling options.</p>
+    <p>Click the point cloud icon in the top-left corner to open the control panel. You can load LAS/LAZ files and adjust styling options.</p>
   </div>
   <script type="module" src="./main.ts"></script>
 </body>

--- a/examples/basic/main.ts
+++ b/examples/basic/main.ts
@@ -91,7 +91,7 @@ map.on('load', () => {
   map.addControl(layerControl, 'top-right');
 
   // Add LidarControl after LayerControl
-  map.addControl(lidarControl, 'top-right');
+  map.addControl(lidarControl, 'top-left');
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-lidar",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-lidar",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@deck.gl/core": ">=9.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-lidar",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "A MapLibre GL JS plugin for visualizing LiDAR point clouds using deck.gl",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/lib/core/LidarControl.ts
+++ b/src/lib/core/LidarControl.ts
@@ -44,6 +44,7 @@ const DEFAULT_OPTIONS: Required<Omit<LidarControlOptions, 'pickInfoFields' | 'co
   title: 'LiDAR Viewer',
   panelWidth: 365,
   maxHeight: 500,
+  theme: 'auto',
   className: '',
   pointSize: 2,
   opacity: 1.0,
@@ -106,6 +107,13 @@ export class LidarControl implements IControl {
   private _mapResizeHandler: (() => void) | null = null;
   private _clickOutsideHandler: ((e: MouseEvent) => void) | null = null;
 
+  // User-defined panel size from dragging the resize handle (null = auto)
+  private _userPanelWidth: number | null = null;
+  private _userPanelHeight: number | null = null;
+  private _resizeHandle?: HTMLElement;
+  private _panelResizeCleanup: (() => void) | null = null;
+  private _maxHeightExplicit = false;
+
   // Core components
   private _deckOverlay?: DeckOverlay;
   private _pointCloudManager?: PointCloudManager;
@@ -138,6 +146,9 @@ export class LidarControl implements IControl {
    */
   constructor(options?: Partial<LidarControlOptions>) {
     this._options = { ...DEFAULT_OPTIONS, ...options };
+    // Track whether the caller explicitly capped the panel height. When they
+    // did not, the panel fills the available vertical space instead.
+    this._maxHeightExplicit = options?.maxHeight !== undefined;
     // Build default color range from options or use defaults
     const defaultColorRange: ColorRangeConfig = this._options.colorRange ?? {
       mode: 'percentile',
@@ -203,6 +214,10 @@ export class LidarControl implements IControl {
       onHover: (info) => this._handlePointHover(info),
     });
 
+    // Apply the color theme (sets a class on <html> so body-level panels
+    // and modals inherit the right CSS variables too).
+    this._applyTheme(this._options.theme);
+
     // Create tooltip element
     this._tooltip = this._createTooltip();
     document.body.appendChild(this._tooltip);
@@ -263,6 +278,16 @@ export class LidarControl implements IControl {
     if (this._clickOutsideHandler) {
       document.removeEventListener('click', this._clickOutsideHandler);
       this._clickOutsideHandler = null;
+    }
+    if (this._panelResizeCleanup) {
+      this._panelResizeCleanup();
+      this._panelResizeCleanup = null;
+    }
+    this._resizeHandle = undefined;
+
+    // Remove the theme override class from the document root.
+    if (typeof document !== 'undefined') {
+      document.documentElement.classList.remove('lidar-theme-light', 'lidar-theme-dark');
     }
 
     // Remove tooltip
@@ -2239,6 +2264,14 @@ export class LidarControl implements IControl {
     panel.appendChild(header);
     panel.appendChild(content);
 
+    // Drag-to-resize handle (corner is set in _updatePanelPosition()).
+    const resizeHandle = document.createElement('div');
+    resizeHandle.className = 'lidar-control-resize-handle corner-bottom-left';
+    resizeHandle.setAttribute('aria-hidden', 'true');
+    panel.appendChild(resizeHandle);
+    this._resizeHandle = resizeHandle;
+    this._setupPanelResize(resizeHandle, panel);
+
     return panel;
   }
 
@@ -2611,6 +2644,10 @@ export class LidarControl implements IControl {
 
     const panelGap = 5; // Gap between button and panel
     let availableHeight = mapRect.height - panelGap * 2;
+    let availableWidth = mapRect.width - panelGap * 2;
+    // The resize handle goes on the corner opposite the map anchor so the
+    // anchored corner stays fixed while dragging.
+    let handleCorner = 'corner-bottom-left';
 
     // Reset all positioning
     this._panel.style.top = '';
@@ -2624,6 +2661,8 @@ export class LidarControl implements IControl {
         this._panel.style.top = `${buttonTop + buttonRect.height + panelGap}px`;
         this._panel.style.left = `${buttonLeft}px`;
         availableHeight = mapRect.height - (buttonTop + buttonRect.height + panelGap) - panelGap;
+        availableWidth = mapRect.width - buttonLeft - panelGap;
+        handleCorner = 'corner-bottom-right';
         break;
 
       case 'top-right':
@@ -2631,6 +2670,8 @@ export class LidarControl implements IControl {
         this._panel.style.top = `${buttonTop + buttonRect.height + panelGap}px`;
         this._panel.style.right = `${buttonRight}px`;
         availableHeight = mapRect.height - (buttonTop + buttonRect.height + panelGap) - panelGap;
+        availableWidth = mapRect.width - buttonRight - panelGap;
+        handleCorner = 'corner-bottom-left';
         break;
 
       case 'bottom-left':
@@ -2638,6 +2679,8 @@ export class LidarControl implements IControl {
         this._panel.style.bottom = `${buttonBottom + buttonRect.height + panelGap}px`;
         this._panel.style.left = `${buttonLeft}px`;
         availableHeight = mapRect.height - (buttonBottom + buttonRect.height + panelGap) - panelGap;
+        availableWidth = mapRect.width - buttonLeft - panelGap;
+        handleCorner = 'corner-top-right';
         break;
 
       case 'bottom-right':
@@ -2645,23 +2688,161 @@ export class LidarControl implements IControl {
         this._panel.style.bottom = `${buttonBottom + buttonRect.height + panelGap}px`;
         this._panel.style.right = `${buttonRight}px`;
         availableHeight = mapRect.height - (buttonBottom + buttonRect.height + panelGap) - panelGap;
+        availableWidth = mapRect.width - buttonRight - panelGap;
+        handleCorner = 'corner-top-left';
         break;
     }
 
-    const panelMaxHeight = Math.max(220, availableHeight);
-    this._panel.style.maxHeight = `${panelMaxHeight}px`;
+    availableHeight = Math.max(LidarControl.MIN_PANEL_HEIGHT, availableHeight);
+    availableWidth = Math.max(LidarControl.MIN_PANEL_WIDTH, availableWidth);
 
-    const header = this._panel.querySelector('.lidar-control-header') as HTMLElement | null;
-    const content = this._panel.querySelector('.lidar-control-content') as HTMLElement | null;
-    if (content) {
-      const headerHeight = header?.offsetHeight ?? 0;
-      const panelPadding = 16;
-      const contentMaxHeight = Math.max(
-        180,
-        Math.min(this._state.maxHeight, panelMaxHeight - headerHeight - panelPadding)
+    // Width: honor a user-dragged width (clamped), else the configured default.
+    const defaultWidth = this._userPanelWidth ?? this._options.panelWidth;
+    const width = Math.min(
+      Math.max(defaultWidth, LidarControl.MIN_PANEL_WIDTH),
+      availableWidth
+    );
+    this._panel.style.width = `${width}px`;
+
+    // Height: the flex content area scrolls vertically only when it overflows.
+    // A user-dragged height is honored (clamped to the available space). When
+    // no height is set, the panel fills the available vertical space, unless
+    // the caller explicitly capped it via the `maxHeight` option.
+    if (this._userPanelHeight !== null) {
+      this._panel.style.maxHeight = `${availableHeight}px`;
+      const height = Math.min(
+        Math.max(this._userPanelHeight, LidarControl.MIN_PANEL_HEIGHT),
+        availableHeight
       );
-      content.style.maxHeight = `${contentMaxHeight}px`;
+      this._panel.style.height = `${height}px`;
+    } else if (this._maxHeightExplicit) {
+      // Caller capped the height: size to content up to the cap.
+      const cap = Math.min(
+        availableHeight,
+        Math.max(this._options.maxHeight, LidarControl.MIN_PANEL_HEIGHT)
+      );
+      this._panel.style.maxHeight = `${cap}px`;
+      this._panel.style.height = '';
+    } else {
+      // Default: fill all available vertical space.
+      this._panel.style.maxHeight = `${availableHeight}px`;
+      this._panel.style.height = `${availableHeight}px`;
     }
+
+    // Move the resize handle to the corner opposite the map anchor.
+    if (this._resizeHandle) {
+      this._resizeHandle.className = `lidar-control-resize-handle ${handleCorner}`;
+    }
+  }
+
+  /** Minimum panel width when resizing (px). */
+  private static readonly MIN_PANEL_WIDTH = 240;
+  /** Minimum panel height when resizing (px). */
+  private static readonly MIN_PANEL_HEIGHT = 160;
+
+  /**
+   * Wires up drag-to-resize on the panel's corner handle. The panel keeps its
+   * map-anchored corner fixed, so the handle on the opposite corner grows or
+   * shrinks the panel width and height.
+   *
+   * @param handle - The resize handle element
+   * @param panel - The panel element being resized
+   */
+  private _setupPanelResize(handle: HTMLElement, panel: HTMLElement): void {
+    let startX = 0;
+    let startY = 0;
+    let startWidth = 0;
+    let startHeight = 0;
+    let anchorRight = false;
+    let anchorBottom = false;
+
+    const onPointerMove = (e: PointerEvent): void => {
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+      this._userPanelWidth = startWidth + (anchorRight ? -dx : dx);
+      this._userPanelHeight = startHeight + (anchorBottom ? -dy : dy);
+      this._updatePanelPosition();
+    };
+
+    const onPointerUp = (e: PointerEvent): void => {
+      try {
+        handle.releasePointerCapture(e.pointerId);
+      } catch {
+        // ignore - pointer may already be released
+      }
+      document.removeEventListener('pointermove', onPointerMove);
+      document.removeEventListener('pointerup', onPointerUp);
+    };
+
+    const onPointerDown = (e: PointerEvent): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      const rect = panel.getBoundingClientRect();
+      startX = e.clientX;
+      startY = e.clientY;
+      startWidth = rect.width;
+      startHeight = rect.height;
+      // Handle on a *-left corner means the panel is anchored to the right;
+      // a top-* corner means it is anchored to the bottom.
+      anchorRight =
+        handle.classList.contains('corner-bottom-left') ||
+        handle.classList.contains('corner-top-left');
+      anchorBottom =
+        handle.classList.contains('corner-top-left') ||
+        handle.classList.contains('corner-top-right');
+      try {
+        handle.setPointerCapture(e.pointerId);
+      } catch {
+        // ignore - capture is best-effort
+      }
+      document.addEventListener('pointermove', onPointerMove);
+      document.addEventListener('pointerup', onPointerUp);
+    };
+
+    handle.addEventListener('pointerdown', onPointerDown);
+    this._panelResizeCleanup = (): void => {
+      handle.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('pointermove', onPointerMove);
+      document.removeEventListener('pointerup', onPointerUp);
+    };
+  }
+
+  /**
+   * Applies a color theme by toggling a class on the document root. Using the
+   * root element (rather than the control) ensures panels and modals appended
+   * to <body> inherit the same theme variables. `'auto'` removes the override
+   * classes so the CSS `prefers-color-scheme` media query takes effect.
+   *
+   * @param theme - The theme to apply
+   */
+  private _applyTheme(theme: 'auto' | 'light' | 'dark'): void {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    root.classList.remove('lidar-theme-light', 'lidar-theme-dark');
+    if (theme === 'dark') {
+      root.classList.add('lidar-theme-dark');
+    } else if (theme === 'light') {
+      root.classList.add('lidar-theme-light');
+    }
+  }
+
+  /**
+   * Sets the color theme of the control at runtime.
+   *
+   * @param theme - `'auto'` (follow OS), `'light'`, or `'dark'`
+   */
+  setTheme(theme: 'auto' | 'light' | 'dark'): void {
+    this._options.theme = theme;
+    this._applyTheme(theme);
+    // Canvas charts resolve their colors from CSS variables, so redraw them.
+    this._crossSectionPanel?.refreshTheme();
+  }
+
+  /**
+   * Returns the currently configured theme.
+   */
+  getTheme(): 'auto' | 'light' | 'dark' {
+    return this._options.theme;
   }
 
   // ==================== Metadata Viewer API ====================

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -115,10 +115,23 @@ export interface LidarControlOptions {
 
   /**
    * Maximum height of the control panel in pixels.
-   * When content exceeds this height, a vertical scrollbar appears.
+   * When set, the panel will not grow taller than this and a vertical
+   * scrollbar appears once the content overflows. When omitted, the panel
+   * expands to use all available vertical space within the map and shows a
+   * vertical scrollbar only as needed. Users can also drag the corner handle
+   * to resize the panel manually.
    * @default 500
    */
   maxHeight?: number;
+
+  /**
+   * Color theme for the control UI.
+   * - `'auto'` follows the OS / browser `prefers-color-scheme` setting (default)
+   * - `'light'` forces the light theme
+   * - `'dark'` forces the dark theme (useful with dark basemaps)
+   * @default 'auto'
+   */
+  theme?: 'auto' | 'light' | 'dark';
 
   /**
    * Custom CSS class name for the control container

--- a/src/lib/gui/CrossSectionPanel.ts
+++ b/src/lib/gui/CrossSectionPanel.ts
@@ -110,6 +110,15 @@ export class CrossSectionPanel {
   }
 
   /**
+   * Redraws the elevation charts so their canvas colors pick up the active
+   * light/dark theme.
+   */
+  refreshTheme(): void {
+    this._chart.redraw();
+    this._popupChart?.redraw();
+  }
+
+  /**
    * Updates the elevation profile display.
    *
    * @param profile - Elevation profile data

--- a/src/lib/gui/ElevationProfileChart.ts
+++ b/src/lib/gui/ElevationProfileChart.ts
@@ -28,6 +28,14 @@ export class ElevationProfileChart {
   private _options: Required<ElevationProfileChartOptions>;
   private _profile: ElevationProfile | null = null;
   private _hoveredPointIndex: number = -1;
+  private _colors = {
+    bg: '#f8f8f8',
+    grid: '#dddddd',
+    axis: '#333333',
+    text: '#333333',
+    muted: '#888888',
+    highlight: '#000000',
+  };
 
   // Chart dimensions (with margins)
   private readonly MARGIN = { top: 20, right: 20, bottom: 40, left: 60 };
@@ -76,6 +84,47 @@ export class ElevationProfileChart {
    */
   render(): HTMLElement {
     return this._container;
+  }
+
+  /**
+   * Redraws the chart. Useful after a theme change since canvas colors are
+   * resolved from CSS variables at draw time.
+   */
+  redraw(): void {
+    this._draw();
+  }
+
+  /**
+   * Resolves the chart's theme colors from CSS custom properties so the
+   * canvas matches the active light/dark theme. Falls back to the light
+   * defaults when a variable is not defined.
+   *
+   * @returns Resolved theme colors
+   */
+  private _themeColors(): {
+    bg: string;
+    grid: string;
+    axis: string;
+    text: string;
+    muted: string;
+    highlight: string;
+  } {
+    const styles =
+      typeof window !== 'undefined'
+        ? window.getComputedStyle(document.documentElement)
+        : null;
+    const read = (name: string, fallback: string): string => {
+      const value = styles?.getPropertyValue(name)?.trim();
+      return value ? value : fallback;
+    };
+    return {
+      bg: read('--lidar-chart-bg', '#f8f8f8'),
+      grid: read('--lidar-chart-grid', '#dddddd'),
+      axis: read('--lidar-chart-axis', '#333333'),
+      text: read('--lidar-chart-text', '#333333'),
+      muted: read('--lidar-chart-muted', '#888888'),
+      highlight: read('--lidar-chart-highlight', '#000000'),
+    };
   }
 
   /**
@@ -130,11 +179,14 @@ export class ElevationProfileChart {
     const { width, height } = this._options;
     const ctx = this._ctx;
 
+    // Resolve theme colors (light/dark) from CSS variables at draw time.
+    this._colors = this._themeColors();
+
     // Clear canvas
     ctx.clearRect(0, 0, width, height);
 
     // Draw background
-    ctx.fillStyle = '#f8f8f8';
+    ctx.fillStyle = this._colors.bg;
     ctx.fillRect(0, 0, width, height);
 
     if (!this._profile || this._profile.points.length === 0) {
@@ -163,7 +215,7 @@ export class ElevationProfileChart {
     const { width, height } = this._options;
     const ctx = this._ctx;
 
-    ctx.fillStyle = '#888';
+    ctx.fillStyle = this._colors.muted;
     ctx.font = '12px sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
@@ -180,7 +232,7 @@ export class ElevationProfileChart {
     const ctx = this._ctx;
     const { left, top } = this.MARGIN;
 
-    ctx.strokeStyle = '#ddd';
+    ctx.strokeStyle = this._colors.grid;
     ctx.lineWidth = 1;
 
     // Horizontal grid lines (5 lines)
@@ -241,7 +293,7 @@ export class ElevationProfileChart {
 
       // Highlight hovered point
       if (i === this._hoveredPointIndex) {
-        ctx.strokeStyle = '#000';
+        ctx.strokeStyle = this._colors.highlight;
         ctx.lineWidth = 2;
         ctx.beginPath();
         ctx.arc(x, y, pointRadius + 2, 0, Math.PI * 2);
@@ -264,7 +316,7 @@ export class ElevationProfileChart {
     const { width, height } = this._options;
     const { stats } = this._profile;
 
-    ctx.strokeStyle = '#333';
+    ctx.strokeStyle = this._colors.axis;
     ctx.lineWidth = 1;
 
     // Y axis
@@ -280,7 +332,7 @@ export class ElevationProfileChart {
     ctx.stroke();
 
     // Axis labels
-    ctx.fillStyle = '#333';
+    ctx.fillStyle = this._colors.text;
     ctx.font = '10px sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';

--- a/src/lib/gui/PanelBuilder.ts
+++ b/src/lib/gui/PanelBuilder.ts
@@ -43,7 +43,6 @@ export class PanelBuilder {
   private _state: LidarState;
 
   // UI component references
-  private _contentElement?: HTMLElement;
   private _fileInput?: FileInput;
   private _urlInput?: HTMLInputElement;
   private _loadButton?: HTMLButtonElement;
@@ -85,11 +84,8 @@ export class PanelBuilder {
   build(): HTMLElement {
     const content = document.createElement('div');
     content.className = 'lidar-control-content';
-    // Apply max height from state
-    if (this._state.maxHeight) {
-      content.style.maxHeight = `${this._state.maxHeight}px`;
-    }
-    this._contentElement = content;
+    // The content fills the panel (flex: 1) and scrolls as needed; the panel's
+    // own height/max-height is managed by LidarControl._updatePanelPosition().
 
     // File input section
     content.appendChild(this._buildFileSection());
@@ -127,11 +123,6 @@ export class PanelBuilder {
    */
   updateState(state: LidarState): void {
     this._state = state;
-
-    // Update max height if changed
-    if (this._contentElement && state.maxHeight) {
-      this._contentElement.style.maxHeight = `${state.maxHeight}px`;
-    }
 
     // Update loading state
     if (this._loadingIndicator) {

--- a/src/lib/styles/lidar-control.css
+++ b/src/lib/styles/lidar-control.css
@@ -2,16 +2,232 @@
  * MapLibre GL LiDAR Control Styles
  */
 
-/* Container - matches maplibregl-ctrl styling */
-.lidar-control {
-  background: #fff;
+/* ====================================================================
+ * Theme tokens
+ *
+ * All colors are driven by these `--lidar-*` custom properties so the
+ * control adapts to light/dark themes. The defaults below are the light
+ * theme. The dark values are applied either automatically (when the OS /
+ * browser reports `prefers-color-scheme: dark`) or explicitly when the
+ * host adds the `lidar-theme-dark` class to <html> (done by the control
+ * when constructed with `theme: 'dark'`).
+ *
+ * Variables are defined on :root so that panels and modals which are
+ * appended to <body> (metadata panel, chart popup, tooltip) inherit them.
+ * ==================================================================== */
+:root {
+  --lidar-bg: #ffffff;
+  --lidar-bg-muted: #f8f9fa;
+  --lidar-bg-subtle: #f0f0f0;
+  --lidar-bg-code: #f5f5f5;
+  --lidar-hover: #e0e0e0;
+  --lidar-active: #d0d0d0;
+
+  --lidar-border: #e0e0e0;
+  --lidar-border-input: #dddddd;
+  --lidar-border-strong: #cccccc;
+  --lidar-border-hover: #bbbbbb;
+  --lidar-border-subtle: rgba(0, 0, 0, 0.15);
+  --lidar-border-dashed: #dddddd;
+
+  --lidar-text: #333333;
+  --lidar-text-strong: #1f2a37;
+  --lidar-text-secondary: #555555;
+  --lidar-text-tertiary: #666666;
+  --lidar-text-muted: #888888;
+  --lidar-text-faint: #999999;
+
+  --lidar-accent: #159895;
+  --lidar-accent-hover: #128784;
+  --lidar-accent-border: #128583;
+  --lidar-accent-dark: #0f6d6b;
+  --lidar-accent-darker: #0b5b59;
+  --lidar-accent-soft: #f0faf9;
+  --lidar-accent-ring: rgba(21, 152, 149, 0.15);
+  --lidar-on-accent: #ffffff;
+
+  --lidar-shadow: rgba(0, 0, 0, 0.1);
+  --lidar-shadow-modal: rgba(0, 0, 0, 0.3);
+  --lidar-backdrop: rgba(0, 0, 0, 0.5);
+  --lidar-overlay: rgba(255, 255, 255, 0.95);
+  --lidar-toggle-hover: rgba(0, 0, 0, 0.05);
+  --lidar-scrollbar: rgba(0, 0, 0, 0.3);
+  --lidar-scrollbar-hover: rgba(0, 0, 0, 0.5);
+  --lidar-tooltip-bg: rgba(0, 0, 0, 0.85);
+  --lidar-tooltip-text: #ffffff;
+
+  --lidar-error-bg: #fff5f5;
+  --lidar-error-border: #ffcdd2;
+  --lidar-error-text: #c62828;
+
+  --lidar-danger: #dc3545;
+  --lidar-danger-bg: #fff5f5;
+  --lidar-danger-on: #ffffff;
+
+  --lidar-info-bg: #e3f2fd;
+  --lidar-info-text: #1565c0;
+  --lidar-info-border: #90caf9;
+
+  --lidar-resize-grip: #cccccc;
+  --lidar-resize-grip-hover: #999999;
+
+  /* Canvas chart tokens (read from JS via getComputedStyle) */
+  --lidar-chart-bg: #f8f8f8;
+  --lidar-chart-grid: #dddddd;
+  --lidar-chart-axis: #333333;
+  --lidar-chart-text: #333333;
+  --lidar-chart-muted: #888888;
+  --lidar-chart-highlight: #000000;
+}
+
+/* Dark theme values, shared by auto-detection and the forced class. */
+@media (prefers-color-scheme: dark) {
+  :root:not(.lidar-theme-light) {
+    --lidar-bg: #1f2127;
+    --lidar-bg-muted: #2a2d35;
+    --lidar-bg-subtle: #313640;
+    --lidar-bg-code: #14161a;
+    --lidar-hover: #3a3f4a;
+    --lidar-active: #454b58;
+
+    --lidar-border: #3a3f4a;
+    --lidar-border-input: #454b58;
+    --lidar-border-strong: #4f5662;
+    --lidar-border-hover: #5a626f;
+    --lidar-border-subtle: rgba(255, 255, 255, 0.15);
+    --lidar-border-dashed: #4f5662;
+
+    --lidar-text: #e6e8ec;
+    --lidar-text-strong: #f2f4f7;
+    --lidar-text-secondary: #c3c8d1;
+    --lidar-text-tertiary: #a7adb8;
+    --lidar-text-muted: #8b919c;
+    --lidar-text-faint: #757b86;
+
+    --lidar-accent: #1bb3af;
+    --lidar-accent-hover: #19a3a0;
+    --lidar-accent-border: #17928f;
+    --lidar-accent-dark: #2bc7c3;
+    --lidar-accent-darker: #3ad4d0;
+    --lidar-accent-soft: rgba(27, 179, 175, 0.18);
+    --lidar-accent-ring: rgba(27, 179, 175, 0.3);
+    --lidar-on-accent: #ffffff;
+
+    --lidar-shadow: rgba(0, 0, 0, 0.5);
+    --lidar-shadow-modal: rgba(0, 0, 0, 0.6);
+    --lidar-backdrop: rgba(0, 0, 0, 0.65);
+    --lidar-overlay: rgba(25, 27, 31, 0.95);
+    --lidar-toggle-hover: rgba(255, 255, 255, 0.08);
+    --lidar-scrollbar: rgba(255, 255, 255, 0.25);
+    --lidar-scrollbar-hover: rgba(255, 255, 255, 0.4);
+    --lidar-tooltip-bg: rgba(0, 0, 0, 0.9);
+    --lidar-tooltip-text: #ffffff;
+
+    --lidar-error-bg: rgba(198, 40, 40, 0.15);
+    --lidar-error-border: rgba(198, 40, 40, 0.5);
+    --lidar-error-text: #f1a9a9;
+
+    --lidar-danger: #e5546a;
+    --lidar-danger-bg: rgba(220, 53, 69, 0.15);
+    --lidar-danger-on: #ffffff;
+
+    --lidar-info-bg: rgba(21, 101, 192, 0.22);
+    --lidar-info-text: #7fb6f0;
+    --lidar-info-border: rgba(144, 202, 249, 0.4);
+
+    --lidar-resize-grip: #5a626f;
+    --lidar-resize-grip-hover: #8b919c;
+
+    --lidar-chart-bg: #1a1c20;
+    --lidar-chart-grid: #3a3f4a;
+    --lidar-chart-axis: #c3c8d1;
+    --lidar-chart-text: #c3c8d1;
+    --lidar-chart-muted: #8b919c;
+    --lidar-chart-highlight: #ffffff;
+  }
+}
+
+/* Forced dark theme (theme: 'dark'), overrides OS preference. */
+:root.lidar-theme-dark {
+  --lidar-bg: #1f2127;
+  --lidar-bg-muted: #2a2d35;
+  --lidar-bg-subtle: #313640;
+  --lidar-bg-code: #14161a;
+  --lidar-hover: #3a3f4a;
+  --lidar-active: #454b58;
+
+  --lidar-border: #3a3f4a;
+  --lidar-border-input: #454b58;
+  --lidar-border-strong: #4f5662;
+  --lidar-border-hover: #5a626f;
+  --lidar-border-subtle: rgba(255, 255, 255, 0.15);
+  --lidar-border-dashed: #4f5662;
+
+  --lidar-text: #e6e8ec;
+  --lidar-text-strong: #f2f4f7;
+  --lidar-text-secondary: #c3c8d1;
+  --lidar-text-tertiary: #a7adb8;
+  --lidar-text-muted: #8b919c;
+  --lidar-text-faint: #757b86;
+
+  --lidar-accent: #1bb3af;
+  --lidar-accent-hover: #19a3a0;
+  --lidar-accent-border: #17928f;
+  --lidar-accent-dark: #2bc7c3;
+  --lidar-accent-darker: #3ad4d0;
+  --lidar-accent-soft: rgba(27, 179, 175, 0.18);
+  --lidar-accent-ring: rgba(27, 179, 175, 0.3);
+  --lidar-on-accent: #ffffff;
+
+  --lidar-shadow: rgba(0, 0, 0, 0.5);
+  --lidar-shadow-modal: rgba(0, 0, 0, 0.6);
+  --lidar-backdrop: rgba(0, 0, 0, 0.65);
+  --lidar-overlay: rgba(25, 27, 31, 0.95);
+  --lidar-toggle-hover: rgba(255, 255, 255, 0.08);
+  --lidar-scrollbar: rgba(255, 255, 255, 0.25);
+  --lidar-scrollbar-hover: rgba(255, 255, 255, 0.4);
+  --lidar-tooltip-bg: rgba(0, 0, 0, 0.9);
+  --lidar-tooltip-text: #ffffff;
+
+  --lidar-error-bg: rgba(198, 40, 40, 0.15);
+  --lidar-error-border: rgba(198, 40, 40, 0.5);
+  --lidar-error-text: #f1a9a9;
+
+  --lidar-danger: #e5546a;
+  --lidar-danger-bg: rgba(220, 53, 69, 0.15);
+  --lidar-danger-on: #ffffff;
+
+  --lidar-info-bg: rgba(21, 101, 192, 0.22);
+  --lidar-info-text: #7fb6f0;
+  --lidar-info-border: rgba(144, 202, 249, 0.4);
+
+  --lidar-resize-grip: #5a626f;
+  --lidar-resize-grip-hover: #8b919c;
+
+  --lidar-chart-bg: #1a1c20;
+  --lidar-chart-grid: #3a3f4a;
+  --lidar-chart-axis: #c3c8d1;
+  --lidar-chart-text: #c3c8d1;
+  --lidar-chart-muted: #8b919c;
+  --lidar-chart-highlight: #ffffff;
+}
+
+/* Container - matches maplibregl-ctrl styling.
+   The selector is intentionally more specific than MapLibre's
+   `.maplibregl-ctrl-group` so the themed background always wins regardless of
+   stylesheet import order, keeping the toggle icon's contrast correct. */
+.lidar-control,
+.maplibregl-ctrl-group.lidar-control {
+  background: var(--lidar-bg);
   border-radius: 4px;
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 0 2px var(--lidar-shadow);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
-/* Toggle button - 29x29 to match navigation control */
-.lidar-control-toggle {
+/* Toggle button - 29x29 to match navigation control. Scoped under
+   .lidar-control so the icon color reliably overrides MapLibre's default
+   button styling and keeps strong contrast against the themed background. */
+.lidar-control .lidar-control-toggle {
   background: none;
   border: none;
   padding: 0;
@@ -22,11 +238,11 @@
   justify-content: center;
   cursor: pointer;
   outline: none;
-  color: #1f2a37;
+  color: var(--lidar-text-strong);
 }
 
-.lidar-control-toggle:hover {
-  background-color: rgba(0, 0, 0, 0.05);
+.lidar-control .lidar-control-toggle:hover {
+  background-color: var(--lidar-toggle-hover);
 }
 
 .lidar-control-toggle .lidar-control-icon {
@@ -51,20 +267,24 @@
 .lidar-control-panel {
   position: absolute;
   /* Position is set dynamically by _updatePanelPosition() */
-  background: #fff;
+  background: var(--lidar-bg);
   border-radius: 4px;
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 0 2px var(--lidar-shadow);
   width: 380px;
-  overflow-y: auto;
-  overflow-x: hidden;
+  /* Panel is a flex column: header stays fixed, content scrolls.
+     overflow is hidden so the resize handle stays pinned to the corner
+     and rounded corners clip cleanly. Horizontal padding lives on the header
+     and content (not the panel) so the content's scrollbar sits flush to the
+     panel edge instead of overlapping the inner components. */
+  overflow: hidden;
   z-index: 1000;
-  padding: 8px;
+  padding: 0;
   font-size: 12px;
   line-height: 1.4;
   display: none;
+  flex-direction: column;
   box-sizing: border-box;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
+  color: var(--lidar-text);
 }
 
 .lidar-control-panel::-webkit-scrollbar {
@@ -76,16 +296,77 @@
 }
 
 .lidar-control-panel::-webkit-scrollbar-thumb {
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: var(--lidar-scrollbar);
   border-radius: 3px;
 }
 
 .lidar-control-panel::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--lidar-scrollbar-hover);
 }
 
 .lidar-control-panel.expanded {
-  display: block;
+  display: flex;
+}
+
+/* Resize handle - sits at the panel corner opposite its map anchor so the
+   anchored corner stays put while dragging. The corner (and cursor) is set
+   from JS via the corner-* modifier classes. */
+.lidar-control-resize-handle {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  z-index: 3;
+  touch-action: none;
+}
+
+.lidar-control-resize-handle::after {
+  content: '';
+  position: absolute;
+  inset: 3px;
+}
+
+.lidar-control-resize-handle.corner-bottom-right {
+  right: 0;
+  bottom: 0;
+  cursor: nwse-resize;
+}
+
+.lidar-control-resize-handle.corner-bottom-right::after {
+  background: linear-gradient(135deg, transparent 50%, var(--lidar-resize-grip) 50%, var(--lidar-resize-grip) 62%, transparent 62%, transparent 74%, var(--lidar-resize-grip) 74%, var(--lidar-resize-grip) 86%, transparent 86%);
+}
+
+.lidar-control-resize-handle.corner-bottom-left {
+  left: 0;
+  bottom: 0;
+  cursor: nesw-resize;
+}
+
+.lidar-control-resize-handle.corner-bottom-left::after {
+  background: linear-gradient(225deg, transparent 50%, var(--lidar-resize-grip) 50%, var(--lidar-resize-grip) 62%, transparent 62%, transparent 74%, var(--lidar-resize-grip) 74%, var(--lidar-resize-grip) 86%, transparent 86%);
+}
+
+.lidar-control-resize-handle.corner-top-right {
+  right: 0;
+  top: 0;
+  cursor: nesw-resize;
+}
+
+.lidar-control-resize-handle.corner-top-right::after {
+  background: linear-gradient(45deg, transparent 50%, var(--lidar-resize-grip) 50%, var(--lidar-resize-grip) 62%, transparent 62%, transparent 74%, var(--lidar-resize-grip) 74%, var(--lidar-resize-grip) 86%, transparent 86%);
+}
+
+.lidar-control-resize-handle.corner-top-left {
+  left: 0;
+  top: 0;
+  cursor: nwse-resize;
+}
+
+.lidar-control-resize-handle.corner-top-left::after {
+  background: linear-gradient(315deg, transparent 50%, var(--lidar-resize-grip) 50%, var(--lidar-resize-grip) 62%, transparent 62%, transparent 74%, var(--lidar-resize-grip) 74%, var(--lidar-resize-grip) 86%, transparent 86%);
+}
+
+.lidar-control-resize-handle:hover {
+  filter: contrast(1.6);
 }
 
 /* Panel header */
@@ -95,10 +376,11 @@
   justify-content: space-between;
   gap: 10px;
   font-weight: 600;
-  color: #333;
-  padding: 4px 0 8px 0;
-  border-bottom: 1px solid #e0e0e0;
+  color: var(--lidar-text);
+  padding: 12px 8px 8px 8px;
+  border-bottom: 1px solid var(--lidar-border);
   margin-bottom: 8px;
+  flex-shrink: 0;
 }
 
 .lidar-control-title {
@@ -111,7 +393,7 @@
   height: 20px;
   border: none;
   background: transparent;
-  color: #999;
+  color: var(--lidar-text-faint);
   font-size: 18px;
   line-height: 1;
   cursor: pointer;
@@ -123,16 +405,31 @@
 }
 
 .lidar-control-close:hover {
-  color: #333;
+  color: var(--lidar-text);
 }
 
 /* Content */
 .lidar-control-content {
+  /* Grow to fill the panel; scroll vertically only when content overflows.
+     Flex column so the share section can be pushed to the bottom edge. The
+     side/bottom padding keeps the (possibly overlay) scrollbar clear of the
+     inner components. */
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 0 8px 0 8px;
   overflow-y: auto;
   overflow-x: hidden;
   position: relative;
   scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
+  scrollbar-color: var(--lidar-scrollbar) transparent;
+}
+
+/* Keep content sections at their natural height (no flex squish) so the panel
+   scrolls when content overflows instead of compressing the controls. */
+.lidar-control-content > * {
+  flex-shrink: 0;
 }
 
 .lidar-control-content::-webkit-scrollbar {
@@ -144,19 +441,19 @@
 }
 
 .lidar-control-content::-webkit-scrollbar-thumb {
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: var(--lidar-scrollbar);
   border-radius: 3px;
 }
 
 .lidar-control-content::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--lidar-scrollbar-hover);
 }
 
 /* Sections */
 .lidar-control-section {
   margin-bottom: 12px;
   padding-bottom: 12px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--lidar-border);
 }
 
 .lidar-control-section:last-child {
@@ -168,7 +465,7 @@
 .lidar-control-section-header {
   font-weight: 600;
   font-size: 11px;
-  color: #666;
+  color: var(--lidar-text-tertiary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 8px;
@@ -188,7 +485,7 @@
   margin-bottom: 4px;
   font-size: 11px;
   font-weight: 500;
-  color: #555;
+  color: var(--lidar-text-secondary);
 }
 
 .lidar-control-label-row {
@@ -200,7 +497,7 @@
 
 .lidar-control-value {
   font-size: 11px;
-  color: #666;
+  color: var(--lidar-text-tertiary);
   font-weight: 500;
 }
 
@@ -208,32 +505,35 @@
   width: 100%;
   padding: 6px 8px;
   font-size: 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--lidar-border-input);
   border-radius: 4px;
   outline: none;
   transition: border-color 0.15s, box-shadow 0.15s;
   box-sizing: border-box;
+  background: var(--lidar-bg);
+  color: var(--lidar-text);
 }
 
 .lidar-control-input:focus {
-  border-color: #159895;
-  box-shadow: 0 0 0 2px rgba(21, 152, 149, 0.15);
+  border-color: var(--lidar-accent);
+  box-shadow: 0 0 0 2px var(--lidar-accent-ring);
 }
 
 .lidar-control-select {
   width: 100%;
   padding: 6px 8px;
   font-size: 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--lidar-border-input);
   border-radius: 4px;
   outline: none;
-  background: #fff;
+  background: var(--lidar-bg);
+  color: var(--lidar-text);
   cursor: pointer;
 }
 
 .lidar-control-select:focus {
-  border-color: #159895;
-  box-shadow: 0 0 0 2px rgba(21, 152, 149, 0.15);
+  border-color: var(--lidar-accent);
+  box-shadow: 0 0 0 2px var(--lidar-accent-ring);
 }
 
 /* Slider */
@@ -241,7 +541,7 @@
   width: 100%;
   height: 4px;
   border-radius: 2px;
-  background: #e0e0e0;
+  background: var(--lidar-hover);
   outline: none;
   -webkit-appearance: none;
   margin-top: 4px;
@@ -252,20 +552,20 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: #159895;
+  background: var(--lidar-accent);
   cursor: pointer;
-  border: 2px solid #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  border: 2px solid var(--lidar-bg);
+  box-shadow: 0 1px 3px var(--lidar-shadow-modal);
 }
 
 .lidar-control-slider::-moz-range-thumb {
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: #159895;
+  background: var(--lidar-accent);
   cursor: pointer;
-  border: 2px solid #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  border: 2px solid var(--lidar-bg);
+  box-shadow: 0 1px 3px var(--lidar-shadow-modal);
 }
 
 /* Button */
@@ -276,8 +576,8 @@
   padding: 6px 12px;
   font-size: 12px;
   font-weight: 500;
-  color: white;
-  background: #159895;
+  color: var(--lidar-on-accent);
+  background: var(--lidar-accent);
   border: none;
   border-radius: 4px;
   cursor: pointer;
@@ -285,21 +585,21 @@
 }
 
 .lidar-control-button:hover {
-  background: #128784;
+  background: var(--lidar-accent-hover);
 }
 
 .lidar-control-button:disabled {
-  background: #ccc;
+  background: var(--lidar-border-strong);
   cursor: not-allowed;
 }
 
 .lidar-control-button.secondary {
-  background: #f0f0f0;
-  color: #333;
+  background: var(--lidar-bg-subtle);
+  color: var(--lidar-text);
 }
 
 .lidar-control-button.secondary:hover {
-  background: #e0e0e0;
+  background: var(--lidar-hover);
 }
 
 .lidar-share-section {
@@ -309,8 +609,13 @@
   position: sticky;
   bottom: 0;
   z-index: 2;
-  background: #fff;
+  background: var(--lidar-bg);
   padding-top: 10px;
+  padding-bottom: 8px;
+  /* Pin to the bottom of the panel when content does not fill the height. The
+     solid background and full-height footer keep scrolled content from peeking
+     through beneath the sticky button. */
+  margin-top: auto;
 }
 
 .lidar-share-button {
@@ -319,7 +624,7 @@
 
 .lidar-share-status {
   min-height: 16px;
-  color: #555;
+  color: var(--lidar-text-secondary);
   font-size: 11px;
   text-align: center;
 }
@@ -349,24 +654,24 @@
   justify-content: center;
   gap: 8px;
   padding: 16px;
-  background: #f8f9fa;
-  border: 2px dashed #ddd;
+  background: var(--lidar-bg-muted);
+  border: 2px dashed var(--lidar-border-dashed);
   border-radius: 4px;
   cursor: pointer;
   transition: border-color 0.15s, background 0.15s;
-  color: #666;
+  color: var(--lidar-text-tertiary);
   font-size: 12px;
   text-align: center;
 }
 
 .lidar-file-input-label:hover,
 .lidar-file-input-label.drag-over {
-  border-color: #159895;
-  background: #f0faf9;
+  border-color: var(--lidar-accent);
+  background: var(--lidar-accent-soft);
 }
 
 .lidar-file-input-label svg {
-  color: #999;
+  color: var(--lidar-text-faint);
 }
 
 /* Point cloud list */
@@ -382,7 +687,7 @@
 }
 
 .lidar-pointclouds-empty {
-  color: #999;
+  color: var(--lidar-text-faint);
   font-size: 11px;
   font-style: italic;
   text-align: center;
@@ -394,7 +699,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 8px;
-  background: #f8f9fa;
+  background: var(--lidar-bg-muted);
   border-radius: 4px;
   margin-bottom: 4px;
 }
@@ -419,7 +724,7 @@
 
 .lidar-pointcloud-details {
   font-size: 10px;
-  color: #888;
+  color: var(--lidar-text-muted);
   margin-top: 2px;
 }
 
@@ -434,11 +739,11 @@
   justify-content: center;
   padding: 4px 10px;
   font-size: 10px;
-  background: #f0f0f0;
-  border: 1px solid #ccc;
+  background: var(--lidar-bg-subtle);
+  border: 1px solid var(--lidar-border-strong);
   border-radius: 3px;
   cursor: pointer;
-  color: #333;
+  color: var(--lidar-text);
   font-weight: 500;
   width: 64px;
   height: auto;
@@ -448,19 +753,19 @@
 }
 
 .lidar-control-panel .lidar-pointcloud-action:hover {
-  background: #e0e0e0;
-  border-color: #bbb;
+  background: var(--lidar-hover);
+  border-color: var(--lidar-border-hover);
 }
 
 .lidar-control-panel .lidar-pointcloud-action.remove {
-  background: #fff5f5;
-  color: #dc3545;
-  border-color: #dc3545;
+  background: var(--lidar-danger-bg);
+  color: var(--lidar-danger);
+  border-color: var(--lidar-danger);
 }
 
 .lidar-control-panel .lidar-pointcloud-action.remove:hover {
-  background: #dc3545;
-  color: #fff;
+  background: var(--lidar-danger);
+  color: var(--lidar-danger-on);
 }
 
 /* Loading state */
@@ -470,9 +775,9 @@
   align-items: center;
   justify-content: center;
   padding: 24px 16px;
-  color: #666;
+  color: var(--lidar-text-tertiary);
   font-size: 12px;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--lidar-overlay);
   position: absolute;
   top: 0;
   left: 0;
@@ -489,8 +794,8 @@
 .lidar-loading-spinner {
   width: 32px;
   height: 32px;
-  border: 3px solid #e0e0e0;
-  border-top-color: #159895;
+  border: 3px solid var(--lidar-hover);
+  border-top-color: var(--lidar-accent);
   border-radius: 50%;
   animation: lidar-spin 0.8s linear infinite;
   margin-bottom: 12px;
@@ -499,19 +804,19 @@
 .lidar-loading-text {
   font-size: 13px;
   font-weight: 500;
-  color: #333;
+  color: var(--lidar-text);
   margin-bottom: 8px;
 }
 
 .lidar-loading-progress {
   font-size: 11px;
-  color: #666;
+  color: var(--lidar-text-tertiary);
 }
 
 .lidar-loading-bar {
   width: 200px;
   height: 4px;
-  background: #e0e0e0;
+  background: var(--lidar-hover);
   border-radius: 2px;
   margin-top: 12px;
   overflow: hidden;
@@ -519,7 +824,7 @@
 
 .lidar-loading-bar-fill {
   height: 100%;
-  background: #159895;
+  background: var(--lidar-accent);
   border-radius: 2px;
   transition: width 0.2s ease;
   width: 0%;
@@ -534,10 +839,10 @@
 /* Error state */
 .lidar-error {
   padding: 8px;
-  background: #fff5f5;
-  border: 1px solid #ffcdd2;
+  background: var(--lidar-error-bg);
+  border: 1px solid var(--lidar-error-border);
   border-radius: 4px;
-  color: #c62828;
+  color: var(--lidar-error-text);
   font-size: 11px;
   margin-top: 8px;
   word-wrap: break-word;
@@ -562,7 +867,7 @@
 /* Scrollbar styling for pointclouds list */
 .lidar-pointclouds-list {
   scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
+  scrollbar-color: var(--lidar-scrollbar) transparent;
 }
 
 .lidar-pointclouds-list::-webkit-scrollbar {
@@ -574,14 +879,14 @@
 }
 
 .lidar-pointclouds-list::-webkit-scrollbar-thumb {
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: var(--lidar-scrollbar);
   border-radius: 3px;
 }
 
 /* Classification Legend */
 .lidar-classification-legend {
   margin-top: 8px;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--lidar-border);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -590,8 +895,8 @@
   display: flex;
   gap: 8px;
   padding: 6px 8px;
-  background: #f8f9fa;
-  border-bottom: 1px solid #e0e0e0;
+  background: var(--lidar-bg-muted);
+  border-bottom: 1px solid var(--lidar-border);
 }
 
 .lidar-legend-action-btn {
@@ -599,32 +904,32 @@
   padding: 4px 8px;
   font-size: 10px;
   font-weight: 500;
-  background-color: #159895;
-  border: 1px solid #128583;
+  background-color: var(--lidar-accent);
+  border: 1px solid var(--lidar-accent-border);
   border-radius: 3px;
   cursor: pointer;
-  color: #fff;
+  color: var(--lidar-on-accent);
   transition: background-color 0.15s, border-color 0.15s;
 }
 
 .lidar-control-panel .lidar-legend-action-btn {
-  background-color: #159895;
-  border: 1px solid #128583;
-  color: #fff;
+  background-color: var(--lidar-accent);
+  border: 1px solid var(--lidar-accent-border);
+  color: var(--lidar-on-accent);
 }
 
 .lidar-legend-action-btn:hover,
 .lidar-legend-action-btn:focus-visible {
-  background-color: #0f6d6b;
-  border-color: #0b5b59;
-  color: #fff;
+  background-color: var(--lidar-accent-dark);
+  border-color: var(--lidar-accent-darker);
+  color: var(--lidar-on-accent);
 }
 
 .lidar-control-panel .lidar-classification-legend-header button.lidar-legend-action-btn:hover,
 .lidar-control-panel .lidar-classification-legend-header button.lidar-legend-action-btn:focus-visible {
-  background-color: #0f6d6b;
-  border-color: #0b5b59;
-  color: #fff;
+  background-color: var(--lidar-accent-dark);
+  border-color: var(--lidar-accent-darker);
+  color: var(--lidar-on-accent);
 }
 
 .lidar-classification-legend-list {
@@ -632,7 +937,7 @@
   overflow-y: auto;
   padding: 4px 0;
   scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
+  scrollbar-color: var(--lidar-scrollbar) transparent;
 }
 
 .lidar-classification-legend-list::-webkit-scrollbar {
@@ -644,7 +949,7 @@
 }
 
 .lidar-classification-legend-list::-webkit-scrollbar-thumb {
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: var(--lidar-scrollbar);
   border-radius: 3px;
 }
 
@@ -657,7 +962,7 @@
 }
 
 .lidar-classification-legend-item:hover {
-  background: #f8f9fa;
+  background: var(--lidar-bg-muted);
 }
 
 .lidar-classification-legend-item input[type="checkbox"] {
@@ -670,13 +975,13 @@
   width: 16px;
   height: 16px;
   border-radius: 3px;
-  border: 1px solid rgba(0, 0, 0, 0.15);
+  border: 1px solid var(--lidar-border-subtle);
   flex-shrink: 0;
 }
 
 .lidar-classification-label {
   font-size: 11px;
-  color: #333;
+  color: var(--lidar-text);
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
@@ -686,7 +991,7 @@
 .lidar-classification-empty {
   padding: 12px 8px;
   text-align: center;
-  color: #888;
+  color: var(--lidar-text-muted);
   font-size: 11px;
   font-style: italic;
 }
@@ -706,23 +1011,24 @@
   flex: 1;
   padding: 6px 8px;
   font-size: 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--lidar-border-input);
   border-radius: 4px;
   outline: none;
-  background: #fff;
+  background: var(--lidar-bg);
+  color: var(--lidar-text);
   cursor: pointer;
 }
 
 .lidar-colormap-select:focus {
-  border-color: #159895;
-  box-shadow: 0 0 0 2px rgba(21, 152, 149, 0.15);
+  border-color: var(--lidar-accent);
+  box-shadow: 0 0 0 2px var(--lidar-accent-ring);
 }
 
 .lidar-colormap-preview {
   width: 50px;
   height: 14px;
   border-radius: 2px;
-  border: 1px solid rgba(0, 0, 0, 0.15);
+  border: 1px solid var(--lidar-border-subtle);
   flex-shrink: 0;
 }
 
@@ -734,7 +1040,7 @@
 .lidar-colorbar-label {
   font-size: 11px;
   font-weight: 500;
-  color: #555;
+  color: var(--lidar-text-secondary);
   margin-bottom: 4px;
 }
 
@@ -742,7 +1048,7 @@
   width: 100%;
   height: 14px;
   border-radius: 2px;
-  border: 1px solid rgba(0, 0, 0, 0.15);
+  border: 1px solid var(--lidar-border-subtle);
   display: block;
 }
 
@@ -750,7 +1056,7 @@
   display: flex;
   justify-content: space-between;
   font-size: 10px;
-  color: #666;
+  color: var(--lidar-text-tertiary);
   margin-top: 2px;
 }
 
@@ -774,20 +1080,20 @@
 .lidar-range-reset-btn {
   padding: 2px 8px;
   font-size: 10px;
-  background: #f0f0f0;
-  border: 1px solid #ccc;
+  background: var(--lidar-bg-subtle);
+  border: 1px solid var(--lidar-border-strong);
   border-radius: 3px;
   cursor: pointer;
-  color: #555;
+  color: var(--lidar-text-secondary);
 }
 
 .lidar-range-reset-btn:hover {
-  background: #e0e0e0;
-  border-color: #999;
+  background: var(--lidar-hover);
+  border-color: var(--lidar-text-faint);
 }
 
 .lidar-range-reset-btn:active {
-  background: #d0d0d0;
+  background: var(--lidar-active);
 }
 
 .lidar-range-mode {
@@ -802,7 +1108,7 @@
   gap: 4px;
   cursor: pointer;
   font-size: 11px;
-  color: #555;
+  color: var(--lidar-text-secondary);
 }
 
 .lidar-range-mode input[type="radio"] {
@@ -812,14 +1118,14 @@
 
 /* Info button for point cloud items */
 .lidar-control-panel .lidar-pointcloud-action.info {
-  background: #e3f2fd;
-  color: #1565c0;
-  border-color: #90caf9;
+  background: var(--lidar-info-bg);
+  color: var(--lidar-info-text);
+  border-color: var(--lidar-info-border);
 }
 
 .lidar-control-panel .lidar-pointcloud-action.info:hover {
-  background: #1565c0;
-  color: #fff;
+  background: var(--lidar-info-text);
+  color: var(--lidar-on-accent);
 }
 
 /* ==================== Metadata Panel ==================== */
@@ -829,7 +1135,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--lidar-backdrop);
   z-index: 10000;
 }
 
@@ -838,9 +1144,9 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: #fff;
+  background: var(--lidar-bg);
   border-radius: 8px;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 10px 40px var(--lidar-shadow-modal);
   width: 500px;
   max-width: 90vw;
   max-height: 80vh;
@@ -848,6 +1154,7 @@
   z-index: 10001;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-size: 13px;
+  color: var(--lidar-text);
 }
 
 .lidar-metadata-header {
@@ -855,21 +1162,21 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-bottom: 1px solid #e0e0e0;
-  background: #f8f9fa;
+  border-bottom: 1px solid var(--lidar-border);
+  background: var(--lidar-bg-muted);
 }
 
 .lidar-metadata-title {
   font-size: 16px;
   font-weight: 600;
-  color: #333;
+  color: var(--lidar-text);
 }
 
 .lidar-metadata-close {
   background: none;
   border: none;
   font-size: 24px;
-  color: #999;
+  color: var(--lidar-text-faint);
   cursor: pointer;
   padding: 0;
   width: 32px;
@@ -881,8 +1188,8 @@
 }
 
 .lidar-metadata-close:hover {
-  background: #e0e0e0;
-  color: #333;
+  background: var(--lidar-hover);
+  color: var(--lidar-text);
 }
 
 .lidar-metadata-content {
@@ -893,7 +1200,7 @@
 
 .lidar-metadata-section {
   margin-bottom: 12px;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--lidar-border);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -907,21 +1214,21 @@
   align-items: center;
   gap: 8px;
   padding: 10px 12px;
-  background: #f8f9fa;
+  background: var(--lidar-bg-muted);
   cursor: pointer;
   user-select: none;
   font-weight: 600;
   font-size: 12px;
-  color: #555;
+  color: var(--lidar-text-secondary);
 }
 
 .lidar-metadata-section-header:hover {
-  background: #f0f0f0;
+  background: var(--lidar-bg-subtle);
 }
 
 .lidar-metadata-section-toggle {
   font-size: 10px;
-  color: #888;
+  color: var(--lidar-text-muted);
 }
 
 .lidar-metadata-section-title {
@@ -930,7 +1237,7 @@
 
 .lidar-metadata-section-body {
   padding: 12px;
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid var(--lidar-border);
 }
 
 .lidar-metadata-row {
@@ -941,12 +1248,12 @@
 }
 
 .lidar-metadata-label {
-  color: #666;
+  color: var(--lidar-text-tertiary);
   font-weight: 500;
 }
 
 .lidar-metadata-value {
-  color: #333;
+  color: var(--lidar-text);
   text-align: right;
   max-width: 60%;
   word-break: break-all;
@@ -955,12 +1262,12 @@
 .lidar-metadata-subheader {
   font-size: 11px;
   font-weight: 600;
-  color: #888;
+  color: var(--lidar-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin: 12px 0 6px 0;
   padding-top: 8px;
-  border-top: 1px dashed #e0e0e0;
+  border-top: 1px dashed var(--lidar-border);
 }
 
 .lidar-metadata-subheader:first-child {
@@ -979,20 +1286,20 @@
   padding: 6px 12px;
   font-size: 11px;
   font-weight: 500;
-  background: #159895;
-  color: #fff;
+  background: var(--lidar-accent);
+  color: var(--lidar-on-accent);
   border: none;
   border-radius: 4px;
   cursor: pointer;
 }
 
 .lidar-metadata-copy-btn:hover {
-  background: #128784;
+  background: var(--lidar-accent-hover);
 }
 
 .lidar-metadata-code {
-  background: #f5f5f5;
-  border: 1px solid #e0e0e0;
+  background: var(--lidar-bg-code);
+  border: 1px solid var(--lidar-border);
   border-radius: 4px;
   padding: 10px;
   font-family: 'Monaco', 'Consolas', monospace;
@@ -1001,6 +1308,7 @@
   overflow: auto;
   white-space: pre;
   margin: 0;
+  color: var(--lidar-text);
 }
 
 .lidar-metadata-table {
@@ -1013,13 +1321,13 @@
 .lidar-metadata-table td {
   padding: 6px 8px;
   text-align: left;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--lidar-border);
 }
 
 .lidar-metadata-table th {
-  background: #f8f9fa;
+  background: var(--lidar-bg-muted);
   font-weight: 600;
-  color: #555;
+  color: var(--lidar-text-secondary);
 }
 
 .lidar-metadata-table tr:last-child td {
@@ -1039,7 +1347,7 @@
 
 .lidar-section-toggle {
   font-size: 10px;
-  color: #888;
+  color: var(--lidar-text-muted);
   width: 12px;
 }
 
@@ -1054,7 +1362,7 @@
 .lidar-crosssection-header {
   font-size: 12px;
   font-weight: 600;
-  color: #555;
+  color: var(--lidar-text-secondary);
   margin-bottom: 8px;
   display: none; /* Hide since section header already shows title */
 }
@@ -1073,13 +1381,13 @@
 }
 
 .lidar-crosssection-draw.active {
-  background: #e3f2fd;
-  color: #1565c0;
-  border: 1px solid #90caf9;
+  background: var(--lidar-info-bg);
+  color: var(--lidar-info-text);
+  border: 1px solid var(--lidar-info-border);
 }
 
 .lidar-crosssection-chart {
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--lidar-border);
   border-radius: 4px;
   margin: 10px 0;
   overflow: hidden;
@@ -1087,7 +1395,7 @@
 
 .lidar-profile-chart-container {
   position: relative;
-  background: #fff;
+  background: var(--lidar-bg);
 }
 
 .lidar-profile-chart {
@@ -1096,8 +1404,8 @@
 
 .lidar-profile-tooltip {
   position: absolute;
-  background: rgba(0, 0, 0, 0.85);
-  color: #fff;
+  background: var(--lidar-tooltip-bg);
+  color: var(--lidar-tooltip-text);
   padding: 6px 10px;
   border-radius: 4px;
   font-size: 11px;
@@ -1112,7 +1420,7 @@
   grid-template-columns: 1fr 1fr;
   gap: 4px 12px;
   padding: 8px;
-  background: #f8f9fa;
+  background: var(--lidar-bg-muted);
   border-radius: 4px;
   font-size: 11px;
 }
@@ -1123,12 +1431,12 @@
 }
 
 .lidar-crosssection-stat-label {
-  color: #666;
+  color: var(--lidar-text-tertiary);
 }
 
 .lidar-crosssection-stat-value {
   font-weight: 500;
-  color: #333;
+  color: var(--lidar-text);
 }
 
 /* ==================== Chart Popup ==================== */
@@ -1138,7 +1446,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--lidar-backdrop);
   z-index: 10000;
   display: flex;
   align-items: center;
@@ -1147,9 +1455,9 @@
 
 .lidar-chart-popup {
   position: relative;
-  background: #fff;
+  background: var(--lidar-bg);
   border-radius: 8px;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 10px 40px var(--lidar-shadow-modal);
   width: 750px;
   height: 520px;
   max-width: 95vw;
@@ -1157,6 +1465,7 @@
   display: flex;
   flex-direction: column;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: var(--lidar-text);
 }
 
 .lidar-chart-popup-header {
@@ -1164,8 +1473,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 12px 16px;
-  border-bottom: 1px solid #e0e0e0;
-  background: #f8f9fa;
+  border-bottom: 1px solid var(--lidar-border);
+  background: var(--lidar-bg-muted);
   border-radius: 8px 8px 0 0;
   flex-shrink: 0;
 }
@@ -1173,14 +1482,14 @@
 .lidar-chart-popup-title {
   font-size: 14px;
   font-weight: 600;
-  color: #333;
+  color: var(--lidar-text);
 }
 
 .lidar-chart-popup-close {
   background: none;
   border: none;
   font-size: 24px;
-  color: #999;
+  color: var(--lidar-text-faint);
   cursor: pointer;
   padding: 0;
   width: 28px;
@@ -1193,8 +1502,8 @@
 }
 
 .lidar-chart-popup-close:hover {
-  background: #e0e0e0;
-  color: #333;
+  background: var(--lidar-hover);
+  color: var(--lidar-text);
 }
 
 .lidar-chart-popup-content {
@@ -1210,10 +1519,10 @@
   display: flex;
   gap: 24px;
   padding: 12px 16px;
-  background: #f8f9fa;
-  border-top: 1px solid #e0e0e0;
+  background: var(--lidar-bg-muted);
+  border-top: 1px solid var(--lidar-border);
   font-size: 13px;
-  color: #555;
+  color: var(--lidar-text-secondary);
   flex-shrink: 0;
   flex-wrap: wrap;
 }
@@ -1229,10 +1538,10 @@
   width: 20px;
   height: 20px;
   cursor: nwse-resize;
-  background: linear-gradient(135deg, transparent 50%, #ccc 50%, #ccc 60%, transparent 60%, transparent 70%, #ccc 70%, #ccc 80%, transparent 80%);
+  background: linear-gradient(135deg, transparent 50%, var(--lidar-resize-grip) 50%, var(--lidar-resize-grip) 60%, transparent 60%, transparent 70%, var(--lidar-resize-grip) 70%, var(--lidar-resize-grip) 80%, transparent 80%);
   border-radius: 0 0 8px 0;
 }
 
 .lidar-chart-popup-resize:hover {
-  background: linear-gradient(135deg, transparent 50%, #999 50%, #999 60%, transparent 60%, transparent 70%, #999 70%, #999 80%, transparent 80%);
+  background: linear-gradient(135deg, transparent 50%, var(--lidar-resize-grip-hover) 50%, var(--lidar-resize-grip-hover) 60%, transparent 60%, transparent 70%, var(--lidar-resize-grip-hover) 70%, var(--lidar-resize-grip-hover) 80%, transparent 80%);
 }


### PR DESCRIPTION
## Summary

Adds dark-theme support, makes the control panel resizable and full-height, and bumps the minor version to **0.16.0**.

### Dark theme (adaptive)
- All colors are now driven by `--lidar-*` CSS custom properties with a light default palette and a dark palette.
- Follows the OS/browser `prefers-color-scheme` automatically. New `theme` option (`'auto' | 'light' | 'dark'`, default `'auto'`) plus `setTheme()` / `getTheme()` to force a theme at runtime (handy with dark basemaps).
- Forced themes toggle a `lidar-theme-dark` / `lidar-theme-light` class on `<html>` so body-level panels and modals (metadata panel, chart popup, tooltip) inherit the theme.
- The canvas elevation-profile chart resolves its colors from CSS variables and redraws on theme change.

### Toggle icon contrast
- Raised the specificity of the container background and toggle icon color so they always win over MapLibre's `.maplibregl-ctrl-group` defaults regardless of stylesheet load order. Measured contrast is ~14.5:1 in both light and dark (WCAG needs 3:1 for UI components).

### Resizable, full-height panel
- The panel can be resized by dragging a corner handle (placed on the corner opposite the map anchor, so the anchored corner stays put).
- It now uses all available vertical space and shows a vertical scrollbar only when content overflows (removed the hard 500px content cap that limited the height).
- Moved horizontal padding onto the header/content so the (overlay) scrollbar no longer paints over the inner components; the Share footer is pinned to the bottom.

### Example
- `examples/basic`: the LiDAR control is now placed in the **top-left** corner.

## Testing
- Type-check, ESLint, and all 27 unit tests pass; Vite build/CSS bundle succeeds.
- Verified in a real browser (Playwright): auto/forced light & dark themes, panel fill at multiple viewport heights, scrollbar clearance, resize in all anchor positions, icon contrast, and top-left placement in the basic example.

> Note: `npm run build`'s `tsc` step hits a pre-existing `"ignoreDeprecations": "6.0"` value in `tsconfig.json` that is invalid for TS 5.9 (unrelated to this PR). Type-checking here was run with `--ignoreDeprecations 5.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added theme support with automatic OS/browser detection and manual dark/light mode switching via `setTheme()` and `getTheme()` methods
  * Panel is now resizable via a corner drag handle

* **Documentation**
  * Updated documentation describing theming options and resizable panel behavior

* **Style**
  * Implemented CSS variable-driven theming system for seamless light/dark mode support across all UI components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->