### PR TITLE
feat: sample-data dropdown and an option to keep the panel open

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ interface LidarControlOptions {
   panelMaxHeight?: number; // Panel max height with scrollbar (default: 500)
   theme?: 'auto' | 'light' | 'dark'; // Color theme (default: 'auto', follows OS)
   className?: string; // Custom CSS class
+  sampleData?: LidarSampleDataset[]; // Sample point clouds shown as a "Load sample data" dropdown above the URL input (hidden when empty)
+  sampleDataLabel?: string; // Dropdown placeholder (default: 'Load sample data...')
+  closeOnOutsideClick?: boolean; // Collapse on outside click; false keeps the panel open until the close button (default: true)
 
   // Point cloud styling
   pointSize?: number; // Point size in pixels (default: 2)

--- a/examples/basic/main.ts
+++ b/examples/basic/main.ts
@@ -73,6 +73,16 @@ map.on('load', () => {
       percentileLow: 2,            // Lower percentile bound (default: 2)
       percentileHigh: 98,          // Upper percentile bound (default: 98)
     },
+    // Offer the sample as an opt-in "Load sample data" dropdown instead of
+    // auto-loading; the URL input stays empty until the user picks one.
+    sampleData: [
+      {
+        label: 'Autzen',
+        url: 'https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz',
+      },
+    ],
+    // Keep the panel open until the close button is clicked.
+    closeOnOutsideClick: false,
     // copcLoadingMode: 'dynamic',  // Auto-detected for COPC URLs, use 'full' to force download
     // streamingPointBudget: 5_000_000  // Max points in memory for streaming mode
     // maxHeight: 500,
@@ -92,11 +102,6 @@ map.on('load', () => {
 
   // Add LidarControl after LayerControl
   map.addControl(lidarControl, 'top-left');
-
-
-
-  // Load a point cloud programmatically
-  lidarControl.loadPointCloud('https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz');
 
   // Listen for point cloud load events
   lidarControl.on('load', (event) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export { LidarLayerAdapter } from './lib/adapters';
 // Type exports
 export type {
   LidarControlOptions,
+  LidarSampleDataset,
   LidarState,
   LidarControlEvent,
   LidarControlEventHandler,

--- a/src/lib/core/LidarControl.ts
+++ b/src/lib/core/LidarControl.ts
@@ -69,6 +69,9 @@ const DEFAULT_OPTIONS: Required<Omit<LidarControlOptions, 'pickInfoFields' | 'co
   terrainExaggeration: 1.0,
   shareUrl: true,
   restoreFromUrl: true,
+  sampleData: [],
+  sampleDataLabel: 'Load sample data...',
+  closeOnOutsideClick: true,
 };
 
 /**
@@ -2256,7 +2259,11 @@ export class LidarControl implements IControl {
         onCrossSectionPanel: () => this.getCrossSectionPanel().render(),
         onShareUrl: this._options.shareUrl ? () => this.getShareUrl() : undefined,
       },
-      this._state
+      this._state,
+      {
+        sampleData: this._options.sampleData,
+        sampleDataLabel: this._options.sampleDataLabel,
+      }
     );
 
     const content = this._panelBuilder.build();
@@ -2567,25 +2574,29 @@ export class LidarControl implements IControl {
    * Setup event listeners for panel positioning and click-outside behavior.
    */
   private _setupEventListeners(): void {
-    // Click outside to close (check both container and panel since they're now separate)
-    this._clickOutsideHandler = (e: MouseEvent) => {
-      // Don't collapse if cross-section tool is active or has a line drawn
-      // (the second click to finish drawing should not collapse the panel)
-      if (this._crossSectionTool?.isEnabled() || this._crossSectionTool?.getLine()) {
-        return;
-      }
+    // Click outside to close (check both container and panel since they're now
+    // separate). Skipped when closeOnOutsideClick is false, so the panel stays
+    // open until the header close button is used.
+    if (this._options.closeOnOutsideClick !== false) {
+      this._clickOutsideHandler = (e: MouseEvent) => {
+        // Don't collapse if cross-section tool is active or has a line drawn
+        // (the second click to finish drawing should not collapse the panel)
+        if (this._crossSectionTool?.isEnabled() || this._crossSectionTool?.getLine()) {
+          return;
+        }
 
-      const target = e.target as Node;
-      if (
-        this._container &&
-        this._panel &&
-        !this._container.contains(target) &&
-        !this._panel.contains(target)
-      ) {
-        this.collapse();
-      }
-    };
-    document.addEventListener('click', this._clickOutsideHandler);
+        const target = e.target as Node;
+        if (
+          this._container &&
+          this._panel &&
+          !this._container.contains(target) &&
+          !this._panel.contains(target)
+        ) {
+          this.collapse();
+        }
+      };
+      document.addEventListener('click', this._clickOutsideHandler);
+    }
 
     // Update panel position on window resize
     this._resizeHandler = () => {

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -281,6 +281,37 @@ export interface LidarControlOptions {
    * @default 150
    */
   streamingViewportDebounceMs?: number;
+
+  /**
+   * Sample point clouds offered as a "Load sample data" dropdown above the
+   * URL input; picking one fills the input. Omit or leave empty to hide the
+   * dropdown, so the input stays clean for the user's own URLs.
+   */
+  sampleData?: LidarSampleDataset[];
+
+  /**
+   * Placeholder shown in the sample-data dropdown before a selection.
+   * @default 'Load sample data...'
+   */
+  sampleDataLabel?: string;
+
+  /**
+   * Collapse the panel when the user clicks outside it (e.g. on the map).
+   * Set to `false` to keep the panel open until the close button is used.
+   * @default true
+   */
+  closeOnOutsideClick?: boolean;
+}
+
+/**
+ * A named sample point cloud offered as a one-click entry in the panel's
+ * "Load sample data" dropdown. Picking it fills the URL input.
+ */
+export interface LidarSampleDataset {
+  /** Label shown in the dropdown (e.g. 'Autzen'). */
+  label: string;
+  /** Point cloud URL filled into the input when this entry is picked. */
+  url: string;
 }
 
 /**

--- a/src/lib/gui/PanelBuilder.ts
+++ b/src/lib/gui/PanelBuilder.ts
@@ -1,4 +1,11 @@
-import type { LidarState, ColorScheme, PointCloudInfo, ColormapName, ColorRangeConfig } from '../core/types';
+import type {
+  LidarState,
+  ColorScheme,
+  PointCloudInfo,
+  ColormapName,
+  ColorRangeConfig,
+  LidarSampleDataset,
+} from '../core/types';
 import { FileInput } from './FileInput';
 import { RangeSlider } from './RangeSlider';
 import { DualRangeSlider } from './DualRangeSlider';
@@ -41,6 +48,8 @@ export interface PanelBuilderCallbacks {
 export class PanelBuilder {
   private _callbacks: PanelBuilderCallbacks;
   private _state: LidarState;
+  private _sampleData: LidarSampleDataset[];
+  private _sampleDataLabel: string;
 
   // UI component references
   private _fileInput?: FileInput;
@@ -71,9 +80,15 @@ export class PanelBuilder {
   private _classificationLegendContainer?: HTMLElement;
   private _shareFeedbackTimeout?: ReturnType<typeof setTimeout>;
 
-  constructor(callbacks: PanelBuilderCallbacks, initialState: LidarState) {
+  constructor(
+    callbacks: PanelBuilderCallbacks,
+    initialState: LidarState,
+    options?: { sampleData?: LidarSampleDataset[]; sampleDataLabel?: string },
+  ) {
     this._callbacks = callbacks;
     this._state = initialState;
+    this._sampleData = options?.sampleData ?? [];
+    this._sampleDataLabel = options?.sampleDataLabel ?? 'Load sample data...';
   }
 
   /**
@@ -280,6 +295,10 @@ export class PanelBuilder {
     });
     section.appendChild(this._fileInput.render());
 
+    // Sample-data dropdown (opt-in; fills the URL input)
+    const sampleDropdown = this._buildSampleDropdown();
+    if (sampleDropdown) section.appendChild(sampleDropdown);
+
     // URL input
     const urlGroup = document.createElement('div');
     urlGroup.className = 'lidar-control-group';
@@ -326,6 +345,90 @@ export class PanelBuilder {
     section.appendChild(urlGroup);
 
     return section;
+  }
+
+  /**
+   * Builds the "Load sample data" dropdown: a custom (not native `<select>`)
+   * dropdown so the menu themes correctly in dark mode. Picking an entry fills
+   * the URL input. Returns null when no samples are configured.
+   */
+  private _buildSampleDropdown(): HTMLElement | null {
+    if (this._sampleData.length === 0) return null;
+
+    const group = document.createElement('div');
+    group.className = 'lidar-control-group';
+    group.style.marginTop = '12px';
+
+    const label = document.createElement('label');
+    label.className = 'lidar-control-label';
+    label.textContent = 'Sample data';
+    group.appendChild(label);
+
+    const triggerLabel = document.createElement('span');
+    triggerLabel.className = 'lidar-sample-trigger-label';
+    triggerLabel.textContent = this._sampleDataLabel;
+    const caret = document.createElement('span');
+    caret.className = 'lidar-sample-caret';
+    caret.textContent = '▾';
+    const trigger = document.createElement('button');
+    trigger.type = 'button';
+    trigger.className = 'lidar-sample-trigger';
+    trigger.setAttribute('aria-haspopup', 'listbox');
+    trigger.setAttribute('aria-expanded', 'false');
+    trigger.setAttribute('aria-label', this._sampleDataLabel);
+    trigger.appendChild(triggerLabel);
+    trigger.appendChild(caret);
+
+    const menu = document.createElement('div');
+    menu.className = 'lidar-sample-menu';
+    menu.setAttribute('role', 'listbox');
+    menu.hidden = true;
+
+    let menuOpen = false;
+    const setMenuOpen = (open: boolean): void => {
+      menuOpen = open;
+      menu.hidden = !open;
+      trigger.setAttribute('aria-expanded', String(open));
+      trigger.classList.toggle('open', open);
+      if (open) (menu.firstElementChild as HTMLElement | null)?.focus();
+    };
+
+    for (const sample of this._sampleData) {
+      const option = document.createElement('button');
+      option.type = 'button';
+      option.className = 'lidar-sample-option';
+      option.setAttribute('role', 'option');
+      option.textContent = sample.label;
+      option.title = sample.url;
+      option.addEventListener('click', () => {
+        setMenuOpen(false);
+        trigger.focus();
+        if (this._urlInput) this._urlInput.value = sample.url;
+      });
+      menu.appendChild(option);
+    }
+
+    trigger.addEventListener('click', () => setMenuOpen(!menuOpen));
+
+    const dropdown = document.createElement('div');
+    dropdown.className = 'lidar-sample-dropdown';
+    dropdown.appendChild(trigger);
+    dropdown.appendChild(menu);
+    group.appendChild(dropdown);
+
+    // Close on Escape or when focus leaves the dropdown (no document listener).
+    group.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && menuOpen) {
+        setMenuOpen(false);
+        trigger.focus();
+      }
+    });
+    group.addEventListener('focusout', (e) => {
+      const next = e.relatedTarget as Node | null;
+      if (!next || !group.contains(next)) setMenuOpen(false);
+    });
+
+    return group;
   }
 
   /**

--- a/src/lib/styles/lidar-control.css
+++ b/src/lib/styles/lidar-control.css
@@ -519,6 +519,92 @@
   box-shadow: 0 0 0 2px var(--lidar-accent-ring);
 }
 
+/* Sample-data dropdown (custom, so the menu themes correctly in dark mode) */
+.lidar-sample-dropdown {
+  position: relative;
+}
+
+.lidar-sample-trigger {
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  text-align: left;
+  border: 1px solid var(--lidar-border-input);
+  border-radius: 4px;
+  background: var(--lidar-bg);
+  color: var(--lidar-text-muted);
+  cursor: pointer;
+  outline: none;
+}
+
+.lidar-sample-trigger:hover,
+.lidar-sample-trigger.open,
+.lidar-sample-trigger:focus-visible {
+  border-color: var(--lidar-accent);
+}
+
+.lidar-sample-trigger-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lidar-sample-caret {
+  flex: 0 0 auto;
+  font-size: 10px;
+}
+
+.lidar-sample-menu {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px;
+  box-sizing: border-box;
+  background: var(--lidar-bg);
+  border: 1px solid var(--lidar-border);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.lidar-sample-menu[hidden] {
+  display: none;
+}
+
+.lidar-sample-option {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  text-align: left;
+  border: none;
+  border-radius: 3px;
+  background: none;
+  color: var(--lidar-text);
+  cursor: pointer;
+}
+
+.lidar-sample-option:hover,
+.lidar-sample-option:focus-visible {
+  outline: none;
+  background: var(--lidar-hover);
+}
+
 .lidar-control-select {
   width: 100%;
   padding: 6px 8px;

--- a/tests/panel-share.test.ts
+++ b/tests/panel-share.test.ts
@@ -108,3 +108,43 @@ describe('PanelBuilder share URL button', () => {
     expect(panel.querySelector('.lidar-share-status')?.textContent).toBe('Copy failed');
   });
 });
+
+describe('PanelBuilder sample-data dropdown', () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      value: vi.fn(() => ({
+        createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+        fillRect: vi.fn(),
+        fillStyle: '',
+      })),
+      configurable: true,
+    });
+  });
+
+  it('renders no dropdown when no samples are configured', () => {
+    const panel = new PanelBuilder(createCallbacks(), createState()).build();
+    expect(panel.querySelector('.lidar-sample-menu')).toBeNull();
+  });
+
+  it('renders a dropdown that fills the URL input on selection', () => {
+    const panel = new PanelBuilder(createCallbacks(), createState(), {
+      sampleData: [
+        { label: 'Autzen', url: 'https://example.com/autzen.copc.laz' },
+        { label: 'Montreal', url: 'https://example.com/montreal.copc.laz' },
+      ],
+    }).build();
+
+    const trigger = panel.querySelector('.lidar-sample-trigger') as HTMLButtonElement;
+    expect(
+      trigger.querySelector('.lidar-sample-trigger-label')?.textContent,
+    ).toBe('Load sample data...');
+    const urlInput = panel.querySelector('.lidar-control-input') as HTMLInputElement;
+    expect(urlInput.value).toBe('');
+
+    const options = [...panel.querySelectorAll('.lidar-sample-option')];
+    expect(options.map((o) => o.textContent)).toEqual(['Autzen', 'Montreal']);
+
+    (options[1] as HTMLButtonElement).click();
+    expect(urlInput.value).toBe('https://example.com/montreal.copc.laz');
+  });
+});


### PR DESCRIPTION
## Summary

Adds opt-in panel options to `LidarControl`, all off by default:

- **`sampleData` / `sampleDataLabel`** — a custom (not native `<select>`) "Load sample data" dropdown above the URL input. Picking an entry fills the input (the user still clicks Load), so a host can advertise sample point clouds without prefilling the input. Hidden when no samples are supplied; themes correctly in dark mode.
- **`closeOnOutsideClick`** — when `false`, the panel stays open until the header close button is used.

The basic example adopts the dropdown (Autzen sample), keeps the panel open, and no longer auto-loads.

## Test plan
- `npm test` (29 tests, incl. a new sample-dropdown test) and `npm run build` pass.