### PR TITLE
chore: release v0.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-lidar",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-lidar",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "@deck.gl/core": ">=9.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-lidar",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "A MapLibre GL JS plugin for visualizing LiDAR point clouds using deck.gl",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Release v0.16.1. Adds the opt-in `sampleData` / `sampleDataLabel` "Load sample data" dropdown. Bumps package.json to 0.16.1.