### PR TITLE
fix: size the LiDAR panel to content by default so it is reducible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-lidar",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-lidar",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "@deck.gl/core": ">=9.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-lidar",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "A MapLibre GL JS plugin for visualizing LiDAR point clouds using deck.gl",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/lib/core/LidarControl.ts
+++ b/src/lib/core/LidarControl.ts
@@ -113,7 +113,6 @@ export class LidarControl implements IControl {
   // User-defined panel size from dragging the resize handle (null = auto)
   private _userPanelWidth: number | null = null;
   private _userPanelHeight: number | null = null;
-  private _resizeHandle?: HTMLElement;
   private _panelResizeCleanup: (() => void) | null = null;
   private _maxHeightExplicit = false;
 
@@ -286,7 +285,6 @@ export class LidarControl implements IControl {
       this._panelResizeCleanup();
       this._panelResizeCleanup = null;
     }
-    this._resizeHandle = undefined;
 
     // Remove the theme override class from the document root.
     if (typeof document !== 'undefined') {
@@ -2271,13 +2269,8 @@ export class LidarControl implements IControl {
     panel.appendChild(header);
     panel.appendChild(content);
 
-    // Drag-to-resize handle (corner is set in _updatePanelPosition()).
-    const resizeHandle = document.createElement('div');
-    resizeHandle.className = 'lidar-control-resize-handle corner-bottom-left';
-    resizeHandle.setAttribute('aria-hidden', 'true');
-    panel.appendChild(resizeHandle);
-    this._resizeHandle = resizeHandle;
-    this._setupPanelResize(resizeHandle, panel);
+    // Drag-to-resize handles in both bottom corners.
+    this._addResizeHandles(panel);
 
     return panel;
   }
@@ -2656,9 +2649,6 @@ export class LidarControl implements IControl {
     const panelGap = 5; // Gap between button and panel
     let availableHeight = mapRect.height - panelGap * 2;
     let availableWidth = mapRect.width - panelGap * 2;
-    // The resize handle goes on the corner opposite the map anchor so the
-    // anchored corner stays fixed while dragging.
-    let handleCorner = 'corner-bottom-left';
 
     // Reset all positioning
     this._panel.style.top = '';
@@ -2673,7 +2663,6 @@ export class LidarControl implements IControl {
         this._panel.style.left = `${buttonLeft}px`;
         availableHeight = mapRect.height - (buttonTop + buttonRect.height + panelGap) - panelGap;
         availableWidth = mapRect.width - buttonLeft - panelGap;
-        handleCorner = 'corner-bottom-right';
         break;
 
       case 'top-right':
@@ -2682,7 +2671,6 @@ export class LidarControl implements IControl {
         this._panel.style.right = `${buttonRight}px`;
         availableHeight = mapRect.height - (buttonTop + buttonRect.height + panelGap) - panelGap;
         availableWidth = mapRect.width - buttonRight - panelGap;
-        handleCorner = 'corner-bottom-left';
         break;
 
       case 'bottom-left':
@@ -2691,7 +2679,6 @@ export class LidarControl implements IControl {
         this._panel.style.left = `${buttonLeft}px`;
         availableHeight = mapRect.height - (buttonBottom + buttonRect.height + panelGap) - panelGap;
         availableWidth = mapRect.width - buttonLeft - panelGap;
-        handleCorner = 'corner-top-right';
         break;
 
       case 'bottom-right':
@@ -2700,7 +2687,6 @@ export class LidarControl implements IControl {
         this._panel.style.right = `${buttonRight}px`;
         availableHeight = mapRect.height - (buttonBottom + buttonRect.height + panelGap) - panelGap;
         availableWidth = mapRect.width - buttonRight - panelGap;
-        handleCorner = 'corner-top-left';
         break;
     }
 
@@ -2742,11 +2728,6 @@ export class LidarControl implements IControl {
       this._panel.style.maxHeight = `${availableHeight}px`;
       this._panel.style.height = '';
     }
-
-    // Move the resize handle to the corner opposite the map anchor.
-    if (this._resizeHandle) {
-      this._resizeHandle.className = `lidar-control-resize-handle ${handleCorner}`;
-    }
   }
 
   /** Minimum panel width when resizing (px). */
@@ -2755,70 +2736,123 @@ export class LidarControl implements IControl {
   private static readonly MIN_PANEL_HEIGHT = 160;
 
   /**
-   * Wires up drag-to-resize on the panel's corner handle. The panel keeps its
-   * map-anchored corner fixed, so the handle on the opposite corner grows or
-   * shrinks the panel width and height.
+   * Adds drag handles in the panel's bottom-left and bottom-right corners.
+   * Pointer drags resize the panel and the chosen size is kept (in
+   * {@link _userPanelWidth}/{@link _userPanelHeight}) so repositioning does
+   * not reset it.
    *
-   * @param handle - The resize handle element
-   * @param panel - The panel element being resized
+   * @param panel - The panel element to attach handles to
    */
-  private _setupPanelResize(handle: HTMLElement, panel: HTMLElement): void {
-    let startX = 0;
-    let startY = 0;
-    let startWidth = 0;
-    let startHeight = 0;
-    let anchorRight = false;
-    let anchorBottom = false;
+  private _addResizeHandles(panel: HTMLElement): void {
+    for (const side of ['left', 'right'] as const) {
+      const handle = document.createElement('div');
+      handle.className = `lidar-control-resize-handle lidar-control-resize-${side}`;
+      handle.setAttribute('aria-hidden', 'true');
+      handle.addEventListener('pointerdown', (event) =>
+        this._beginResize(event, side, panel, handle)
+      );
+      panel.appendChild(handle);
+    }
+  }
 
-    const onPointerMove = (e: PointerEvent): void => {
-      const dx = e.clientX - startX;
-      const dy = e.clientY - startY;
-      this._userPanelWidth = startWidth + (anchorRight ? -dx : dx);
-      this._userPanelHeight = startHeight + (anchorBottom ? -dy : dy);
-      this._updatePanelPosition();
-    };
+  /**
+   * Starts a pointer-driven resize from one of the bottom-corner handles.
+   *
+   * The panel is first frozen to explicit left/top pixels (clearing any
+   * right/bottom anchor) so the opposite edge stays put no matter which
+   * corner the control sits in. The right handle then grows the panel
+   * rightward, the left handle leftward; both grow it downward. Sizes are
+   * clamped to a sensible minimum and to the map container, and the chosen
+   * size is stored in {@link _userPanelWidth}/{@link _userPanelHeight} so
+   * {@link _updatePanelPosition} reapplies it on later repositioning.
+   *
+   * @param event - The pointerdown event
+   * @param side - Which corner handle started the drag
+   * @param panel - The panel element being resized
+   * @param handle - The handle element (for pointer capture)
+   */
+  private _beginResize(
+    event: PointerEvent,
+    side: 'left' | 'right',
+    panel: HTMLElement,
+    handle: HTMLElement
+  ): void {
+    if (!this._mapContainer) return;
+    event.preventDefault();
+    // Keep the drag from bubbling to the document click-outside handler.
+    event.stopPropagation();
 
-    const onPointerUp = (e: PointerEvent): void => {
-      try {
-        handle.releasePointerCapture(e.pointerId);
-      } catch {
-        // ignore - pointer may already be released
+    const mapRect = this._mapContainer.getBoundingClientRect();
+    const rect = panel.getBoundingClientRect();
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const startWidth = rect.width;
+    const startHeight = rect.height;
+    const startLeft = rect.left - mapRect.left;
+    const startRight = rect.right;
+    const startTop = rect.top;
+
+    const EDGE_MARGIN = 10;
+    // Clamp the preferred minimums to what the map can actually hold, so a
+    // small map container never forces the panel past its edges.
+    const minWidth = Math.min(
+      LidarControl.MIN_PANEL_WIDTH,
+      Math.max(120, mapRect.width - 2 * EDGE_MARGIN)
+    );
+    const minHeight = Math.min(
+      LidarControl.MIN_PANEL_HEIGHT,
+      Math.max(120, mapRect.height - 2 * EDGE_MARGIN)
+    );
+
+    // Pin the panel to its current rect so the size grows from the dragged
+    // corner regardless of the original anchor, and drop the CSS max-size
+    // caps for the duration of the drag.
+    panel.style.left = `${startLeft}px`;
+    panel.style.top = `${startTop - mapRect.top}px`;
+    panel.style.right = '';
+    panel.style.bottom = '';
+    panel.style.maxWidth = 'none';
+    panel.style.maxHeight = 'none';
+
+    const onMove = (moveEvent: PointerEvent): void => {
+      const dx = moveEvent.clientX - startX;
+      const dy = moveEvent.clientY - startY;
+
+      const maxHeight = Math.max(minHeight, mapRect.bottom - startTop - EDGE_MARGIN);
+      const nextHeight = Math.max(minHeight, Math.min(startHeight + dy, maxHeight));
+
+      let nextWidth: number;
+      let nextLeft = startLeft;
+      if (side === 'right') {
+        const maxWidth = Math.max(minWidth, mapRect.right - rect.left - EDGE_MARGIN);
+        nextWidth = Math.max(minWidth, Math.min(startWidth + dx, maxWidth));
+      } else {
+        const maxWidth = Math.max(minWidth, startRight - mapRect.left - EDGE_MARGIN);
+        nextWidth = Math.max(minWidth, Math.min(startWidth - dx, maxWidth));
+        // Hold the right edge fixed while the left edge follows the drag.
+        nextLeft = startLeft + (startWidth - nextWidth);
       }
-      document.removeEventListener('pointermove', onPointerMove);
-      document.removeEventListener('pointerup', onPointerUp);
+
+      panel.style.width = `${nextWidth}px`;
+      panel.style.height = `${nextHeight}px`;
+      panel.style.left = `${nextLeft}px`;
+      this._userPanelWidth = nextWidth;
+      this._userPanelHeight = nextHeight;
     };
 
-    const onPointerDown = (e: PointerEvent): void => {
-      e.preventDefault();
-      e.stopPropagation();
-      const rect = panel.getBoundingClientRect();
-      startX = e.clientX;
-      startY = e.clientY;
-      startWidth = rect.width;
-      startHeight = rect.height;
-      // Handle on a *-left corner means the panel is anchored to the right;
-      // a top-* corner means it is anchored to the bottom.
-      anchorRight =
-        handle.classList.contains('corner-bottom-left') ||
-        handle.classList.contains('corner-top-left');
-      anchorBottom =
-        handle.classList.contains('corner-top-left') ||
-        handle.classList.contains('corner-top-right');
-      try {
-        handle.setPointerCapture(e.pointerId);
-      } catch {
-        // ignore - capture is best-effort
-      }
-      document.addEventListener('pointermove', onPointerMove);
-      document.addEventListener('pointerup', onPointerUp);
+    const cleanup = (): void => {
+      handle.releasePointerCapture?.(event.pointerId);
+      handle.removeEventListener('pointermove', onMove);
+      handle.removeEventListener('pointerup', cleanup);
+      handle.removeEventListener('pointercancel', cleanup);
+      this._panelResizeCleanup = null;
     };
 
-    handle.addEventListener('pointerdown', onPointerDown);
-    this._panelResizeCleanup = (): void => {
-      handle.removeEventListener('pointerdown', onPointerDown);
-      document.removeEventListener('pointermove', onPointerMove);
-      document.removeEventListener('pointerup', onPointerUp);
-    };
+    handle.setPointerCapture?.(event.pointerId);
+    handle.addEventListener('pointermove', onMove);
+    handle.addEventListener('pointerup', cleanup);
+    handle.addEventListener('pointercancel', cleanup);
+    this._panelResizeCleanup = cleanup;
   }
 
   /**

--- a/src/lib/core/LidarControl.ts
+++ b/src/lib/core/LidarControl.ts
@@ -2717,8 +2717,9 @@ export class LidarControl implements IControl {
 
     // Height: the flex content area scrolls vertically only when it overflows.
     // A user-dragged height is honored (clamped to the available space). When
-    // no height is set, the panel fills the available vertical space, unless
-    // the caller explicitly capped it via the `maxHeight` option.
+    // no height is set, the panel sizes to its content, growing up to the
+    // available vertical space, unless the caller explicitly capped it via the
+    // `maxHeight` option.
     if (this._userPanelHeight !== null) {
       this._panel.style.maxHeight = `${availableHeight}px`;
       const height = Math.min(
@@ -2735,9 +2736,11 @@ export class LidarControl implements IControl {
       this._panel.style.maxHeight = `${cap}px`;
       this._panel.style.height = '';
     } else {
-      // Default: fill all available vertical space.
+      // Default: size to content, growing up to the available space and
+      // scrolling the content area on overflow. No explicit height is set so
+      // the panel can shrink to fit short content and stay reducible.
       this._panel.style.maxHeight = `${availableHeight}px`;
-      this._panel.style.height = `${availableHeight}px`;
+      this._panel.style.height = '';
     }
 
     // Move the resize handle to the corner opposite the map anchor.

--- a/src/lib/styles/lidar-control.css
+++ b/src/lib/styles/lidar-control.css
@@ -308,11 +308,12 @@
   display: flex;
 }
 
-/* Resize handle - sits at the panel corner opposite its map anchor so the
-   anchored corner stays put while dragging. The corner (and cursor) is set
-   from JS via the corner-* modifier classes. */
+/* Resize handles - one fixed in each bottom corner. The bottom-right handle
+   grows the panel rightward, the bottom-left handle leftward; both grow it
+   downward. */
 .lidar-control-resize-handle {
   position: absolute;
+  bottom: 0;
   width: 16px;
   height: 16px;
   z-index: 3;
@@ -322,51 +323,37 @@
 .lidar-control-resize-handle::after {
   content: '';
   position: absolute;
-  inset: 3px;
+  bottom: 3px;
+  width: 7px;
+  height: 7px;
+  border-color: var(--lidar-resize-grip);
+  border-style: solid;
+  opacity: 0.7;
 }
 
-.lidar-control-resize-handle.corner-bottom-right {
+.lidar-control-resize-handle:hover::after {
+  border-color: var(--lidar-resize-grip-hover);
+  opacity: 1;
+}
+
+.lidar-control-resize-right {
   right: 0;
-  bottom: 0;
   cursor: nwse-resize;
 }
 
-.lidar-control-resize-handle.corner-bottom-right::after {
-  background: linear-gradient(135deg, transparent 50%, var(--lidar-resize-grip) 50%, var(--lidar-resize-grip) 62%, transparent 62%, transparent 74%, var(--lidar-resize-grip) 74%, var(--lidar-resize-grip) 86%, transparent 86%);
+.lidar-control-resize-right::after {
+  right: 3px;
+  border-width: 0 2px 2px 0;
 }
 
-.lidar-control-resize-handle.corner-bottom-left {
+.lidar-control-resize-left {
   left: 0;
-  bottom: 0;
   cursor: nesw-resize;
 }
 
-.lidar-control-resize-handle.corner-bottom-left::after {
-  background: linear-gradient(225deg, transparent 50%, var(--lidar-resize-grip) 50%, var(--lidar-resize-grip) 62%, transparent 62%, transparent 74%, var(--lidar-resize-grip) 74%, var(--lidar-resize-grip) 86%, transparent 86%);
-}
-
-.lidar-control-resize-handle.corner-top-right {
-  right: 0;
-  top: 0;
-  cursor: nesw-resize;
-}
-
-.lidar-control-resize-handle.corner-top-right::after {
-  background: linear-gradient(45deg, transparent 50%, var(--lidar-resize-grip) 50%, var(--lidar-resize-grip) 62%, transparent 62%, transparent 74%, var(--lidar-resize-grip) 74%, var(--lidar-resize-grip) 86%, transparent 86%);
-}
-
-.lidar-control-resize-handle.corner-top-left {
-  left: 0;
-  top: 0;
-  cursor: nwse-resize;
-}
-
-.lidar-control-resize-handle.corner-top-left::after {
-  background: linear-gradient(315deg, transparent 50%, var(--lidar-resize-grip) 50%, var(--lidar-resize-grip) 62%, transparent 62%, transparent 74%, var(--lidar-resize-grip) 74%, var(--lidar-resize-grip) 86%, transparent 86%);
-}
-
-.lidar-control-resize-handle:hover {
-  filter: contrast(1.6);
+.lidar-control-resize-left::after {
+  left: 3px;
+  border-width: 0 0 2px 2px;
 }
 
 /* Panel header */

--- a/tests/panel-height.test.ts
+++ b/tests/panel-height.test.ts
@@ -5,8 +5,10 @@ type ControlInternals = {
   _container: HTMLElement;
   _panel: HTMLElement;
   _mapContainer: HTMLElement;
+  _userPanelWidth: number | null;
   _userPanelHeight: number | null;
   _updatePanelPosition(): void;
+  _addResizeHandles(panel: HTMLElement): void;
 };
 
 /**
@@ -74,5 +76,68 @@ describe('LidarControl resize handle reducibility', () => {
     internals._userPanelHeight = 400;
     internals._updatePanelPosition();
     expect(panel.style.height).toBe('400px');
+  });
+});
+
+describe('LidarControl bottom-corner resize handles', () => {
+  /** Simulates a pointer drag on a handle from one screen point to another. */
+  function dragHandle(
+    handle: HTMLElement,
+    from: { x: number; y: number },
+    to: { x: number; y: number }
+  ) {
+    const make = (type: string, x: number, y: number) =>
+      new MouseEvent(type, { bubbles: true, clientX: x, clientY: y }) as unknown as PointerEvent;
+    handle.dispatchEvent(make('pointerdown', from.x, from.y));
+    handle.dispatchEvent(make('pointermove', to.x, to.y));
+    handle.dispatchEvent(make('pointerup', to.x, to.y));
+  }
+
+  it('creates exactly two handles, one in each bottom corner', () => {
+    const { panel, internals } = setupControl();
+    internals._addResizeHandles(panel);
+
+    const handles = panel.querySelectorAll('.lidar-control-resize-handle');
+    expect(handles.length).toBe(2);
+    expect(panel.querySelector('.lidar-control-resize-left')).not.toBeNull();
+    expect(panel.querySelector('.lidar-control-resize-right')).not.toBeNull();
+    // The legacy single adaptive handle (corner-* classes) is gone.
+    expect(panel.querySelector('.corner-bottom-left')).toBeNull();
+    expect(panel.querySelector('.corner-bottom-right')).toBeNull();
+  });
+
+  it('grows and shrinks the panel when dragging the bottom-right handle', () => {
+    const { panel, internals } = setupControl();
+    internals._addResizeHandles(panel);
+    // Panel near the top-left of the map so there is room to grow rightward:
+    // 300px wide, 200px tall.
+    panel.getBoundingClientRect = () =>
+      ({ top: 45, bottom: 245, left: 50, right: 350, width: 300, height: 200 }) as DOMRect;
+    const right = panel.querySelector('.lidar-control-resize-right') as HTMLElement;
+
+    // Drag down-right: the panel grows wider and taller.
+    dragHandle(right, { x: 350, y: 245 }, { x: 500, y: 400 });
+    expect(internals._userPanelWidth).toBeGreaterThan(300);
+    expect(internals._userPanelHeight).toBeGreaterThan(200);
+
+    // Drag back up-left from the new bottom-right corner: it shrinks again.
+    panel.getBoundingClientRect = () =>
+      ({ top: 45, bottom: 400, left: 50, right: 500, width: 450, height: 355 }) as DOMRect;
+    dragHandle(right, { x: 500, y: 400 }, { x: 250, y: 100 });
+    expect(internals._userPanelWidth).toBeLessThan(450);
+    expect(internals._userPanelHeight).toBeLessThan(355);
+  });
+
+  it('grows the panel leftward when dragging the bottom-left handle', () => {
+    const { panel, internals } = setupControl();
+    internals._addResizeHandles(panel);
+    panel.getBoundingClientRect = () =>
+      ({ top: 45, bottom: 245, left: 630, right: 995, width: 365, height: 200 }) as DOMRect;
+    const left = panel.querySelector('.lidar-control-resize-left') as HTMLElement;
+
+    // Dragging the bottom-left handle leftward widens the panel.
+    dragHandle(left, { x: 630, y: 245 }, { x: 400, y: 400 });
+    expect(internals._userPanelWidth).toBeGreaterThan(365);
+    expect(internals._userPanelHeight).toBeGreaterThan(200);
   });
 });

--- a/tests/panel-height.test.ts
+++ b/tests/panel-height.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { LidarControl } from '../src/lib/core/LidarControl';
+
+type ControlInternals = {
+  _container: HTMLElement;
+  _panel: HTMLElement;
+  _mapContainer: HTMLElement;
+  _userPanelHeight: number | null;
+  _updatePanelPosition(): void;
+};
+
+/**
+ * Builds the minimal DOM that the panel-position logic reads, with controllable
+ * bounding rectangles, and wires it onto a freshly constructed control without
+ * going through `onAdd` (which needs a real map).
+ */
+function setupControl(options?: ConstructorParameters<typeof LidarControl>[0]) {
+  const control = new LidarControl(options);
+  const internals = control as unknown as ControlInternals;
+
+  const mapContainer = document.createElement('div');
+  const ctrlGroup = document.createElement('div');
+  ctrlGroup.className = 'maplibregl-ctrl-top-right';
+  const container = document.createElement('div');
+  const button = document.createElement('button');
+  button.className = 'lidar-control-toggle';
+  container.appendChild(button);
+  ctrlGroup.appendChild(container);
+  mapContainer.appendChild(ctrlGroup);
+
+  const panel = document.createElement('div');
+  mapContainer.appendChild(panel);
+
+  mapContainer.getBoundingClientRect = () =>
+    ({ top: 0, bottom: 800, left: 0, right: 1000, width: 1000, height: 800 }) as DOMRect;
+  button.getBoundingClientRect = () =>
+    ({ top: 10, bottom: 40, left: 950, right: 990, width: 40, height: 30 }) as DOMRect;
+
+  internals._container = container;
+  internals._panel = panel;
+  internals._mapContainer = mapContainer;
+
+  return { panel, internals };
+}
+
+describe('LidarControl panel height sizing', () => {
+  it('sizes to content by default (no explicit inline height)', () => {
+    const { panel, internals } = setupControl();
+    internals._updatePanelPosition();
+    // The panel may grow up to the available space, so maxHeight is capped,
+    // but no explicit height is forced so it stays content-sized and reducible.
+    expect(panel.style.maxHeight).not.toBe('');
+    expect(panel.style.height).toBe('');
+  });
+
+  it('caps to content up to the maxHeight when the caller sets it', () => {
+    const { panel, internals } = setupControl({ maxHeight: 300 });
+    internals._updatePanelPosition();
+    expect(panel.style.maxHeight).toBe('300px');
+    expect(panel.style.height).toBe('');
+  });
+});
+
+describe('LidarControl resize handle reducibility', () => {
+  it('applies a user-dragged height clamped to the minimum, allowing shrink and grow', () => {
+    const { panel, internals } = setupControl();
+
+    // A tiny dragged height shrinks the panel; below the minimum it clamps.
+    internals._userPanelHeight = 10;
+    internals._updatePanelPosition();
+    expect(panel.style.height).toBe('160px');
+
+    // A larger dragged height grows the panel.
+    internals._userPanelHeight = 400;
+    internals._updatePanelPosition();
+    expect(panel.style.height).toBe('400px');
+  });
+});


### PR DESCRIPTION
The default panel height forced an explicit height equal to the full
available vertical space, so users could not shrink it when the caller
did not set the maxHeight option. Size the panel to its content instead:
keep maxHeight as the available-space cap but drop the forced height so
the panel grows up to that cap, scrolls the content area on overflow,
and stays freely reducible down to MIN_PANEL_HEIGHT via the resize
handle. The explicit-maxHeight and user-dragged branches are unchanged.
