### PR TITLE
opt: more spezf. output colors

### DIFF
--- a/src/lib/colorizers/ColorScheme.ts
+++ b/src/lib/colorizers/ColorScheme.ts
@@ -8,19 +8,19 @@ import { COLORMAPS } from './Colormaps';
  * ASPRS LAS classification standard colors
  */
 export const CLASSIFICATION_COLORS: ClassificationColorMap = {
-  0: [128, 128, 128],   // Created, never classified
-  1: [128, 128, 128],   // Unclassified
-  2: [165, 113, 78],    // Ground (brown)
-  3: [144, 238, 144],   // Low Vegetation (light green)
-  4: [34, 139, 34],     // Medium Vegetation (green)
-  5: [0, 100, 0],       // High Vegetation (dark green)
-  6: [255, 165, 0],     // Building (orange)
-  7: [255, 0, 0],       // Low Point (noise) (red)
-  8: [128, 128, 128],   // Reserved
-  9: [0, 0, 255],       // Water (blue)
+   0: [0, 0, 0],        // Created, never classified (black)
+   1: [128, 128, 128],  // Unclassified (gray:50)
+   2: [165, 113, 78],   // Ground (brown)
+   3: [144, 238, 144],  // Low Vegetation (light green)
+   4: [34, 139, 34],    // Medium Vegetation (green)
+   5: [0, 100, 0],      // High Vegetation (dark green)
+   6: [255, 165, 0],    // Building (orange)
+   7: [255, 0, 0],      // Low Point (noise) (red)
+   8: [0, 0, 0],        // Reserved (black)
+   9: [0, 0, 255],      // Water (blue)
   10: [139, 90, 43],    // Rail
-  11: [128, 128, 128],  // Road Surface
-  12: [128, 128, 128],  // Reserved
+  11: [64, 64, 64],     // Road Surface (gray:25)
+  12: [0, 0, 0],        // Reserved (black)
   13: [255, 255, 0],    // Wire - Guard (yellow)
   14: [255, 200, 0],    // Wire - Conductor
   15: [200, 200, 0],    // Transmission Tower


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated classification colors for several map/layer categories so displayed colors better match the intended labels.
  * Adjusted the default appearance for previously gray classifications, including created/uncategorized, reserved, and road surface entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->