### PR TITLE
chore: release v0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplibre-gl-lidar",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplibre-gl-lidar",
-      "version": "0.16.2",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@deck.gl/core": ">=9.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maplibre-gl-lidar",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "A MapLibre GL JS plugin for visualizing LiDAR point clouds using deck.gl",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Bump version to 0.17.0 for the maplibre-gl v6 support released in #93.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 0.16.2 to 0.17.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->